### PR TITLE
Rng 31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,27 @@
       </plugin>
 
       <plugin>
+          <groupId>net.nicoulaj.maven.plugins</groupId>
+          <artifactId>checksum-maven-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>dependencies</goal>
+                  </goals>
+              </execution>
+          </executions>
+          <configuration>
+              <scopes>
+                  <scope>compile</scope>
+              </scopes>
+              <types>
+                  <type>jar</type>
+              </types>
+          </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -220,6 +241,13 @@
             <exclude>dist-archive/**</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <configuration>
+              <createChecksum>true</createChecksum>
+          </configuration>
       </plugin>
     </plugins>
 

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -22,6 +22,12 @@
     <format>tar.gz</format>
     <format>zip</format>
   </formats>
+  <repositories>
+      <repository>
+          <includeMetadata>true</includeMetadata>
+          <outputDirectory>maven2</outputDirectory>
+      </repository>
+  </repositories>
   <includeSiteDirectory>false</includeSiteDirectory>
   <fileSets>
     <fileSet>

--- a/src/assembly/src.xml
+++ b/src/assembly/src.xml
@@ -21,6 +21,12 @@
     <format>tar.gz</format>
     <format>zip</format>
   </formats>
+  <repositories>
+      <repository>
+          <includeMetadata>true</includeMetadata>
+          <outputDirectory>maven2</outputDirectory>
+      </repository>
+  </repositories>
   <baseDirectory>
      ${project.artifactId}-${commons.release.version}-src
   </baseDirectory>


### PR DESCRIPTION
Maven assembly plugin is not able to produce checksums while assembles artifacts, added checksum artifact which will generate checksums by running 

```
mvn clean assembly:single checksum:artifacts
```