### PR TITLE
Replace FindBugs with SpotBugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ jdk:
   - oraclejdk9
 
 after_success:
-  - mvn clean test pmd:pmd findbugs:findbugs checkstyle:checkstyle jacoco:report coveralls:report
+  - mvn clean test pmd:pmd spotbugs:spotbugs checkstyle:checkstyle jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <rng.pmd.version>3.9.0</rng.pmd.version>
-    <rng.findbugs.version>3.0.5</rng.findbugs.version>
+    <rng.spotbugs.version>3.1.1</rng.spotbugs.version>
     <rng.checkstyle.version>3.0.0</rng.checkstyle.version>
     <rng.clirr.version>2.8</rng.clirr.version>
     <rng.mathjax.version>2.7.2</rng.mathjax.version>
@@ -214,9 +214,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${rng.findbugs.version}</version>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${rng.spotbugs.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
@@ -319,12 +319,12 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${rng.findbugs.version}</version>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${rng.spotbugs.version}</version>
         <configuration>
           <threshold>Normal</threshold>
           <effort>Default</effort>
-          <excludeFilterFile>${rng.parent.dir}/src/main/resources/findbugs/findbugs-exclude-filter.xml</excludeFilterFile>
+          <excludeFilterFile>${rng.parent.dir}/src/main/resources/spotbugs/spotbugs-exclude-filter.xml</excludeFilterFile>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/resources/spotbugs/spotbugs-exclude-filter.xml
+++ b/src/main/resources/spotbugs/spotbugs-exclude-filter.xml
@@ -17,11 +17,14 @@
 -->
 
 <!--
-  This file contains some false positive bugs detected by findbugs. Their
+  This file contains some false positive bugs detected by spotbugs. Their
   false positive nature has been analyzed individually and they have been
-  put here to instruct findbugs it must ignore them.
+  put here to instruct spotbugs it must ignore them.
 -->
-<FindBugsFilter>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.1.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
 
   <Class name="~.*\.jmh\.generated\..*" />
 


### PR DESCRIPTION
As per the discussion in [1], FindBugs has been discontinued, and
SpotBugs has taken its place.
This patch updates the Commons RNG project to use SpotBugs
accordingly.

[1] http://mail-archives.apache.org/mod_mbox/commons-dev/201802.mbox/raw/%3C4131eded52b31d3c9114fa5cbae48c4a%40scarlet.be%3E/
spotbgus