### PR TITLE
Improvement rng 50

### DIFF
--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.distribution.InternalUtils.FactorialLog;
+
+/**
+ * Sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson distribution</a>.
+ *
+ * <ul>
+ *  <li>
+ *   For large means, we use the rejection algorithm described in
+ *   <blockquote>
+ *    Devroye, Luc. (1981).<i>The Computer Generation of Poisson Random Variables</i><br>
+ *    <strong>Computing</strong> vol. 26 pp. 197-207.
+ *   </blockquote>
+ *  </li>
+ * </ul>
+ * 
+ * This sampler is suitable for {@code mean >= 40}.
+ */
+public class LargeMeanPoissonSampler
+    extends SamplerBase
+    implements DiscreteSampler {
+
+    /** Class to compute {@code log(n!)}. This has no cached values. */
+    static private final InternalUtils.FactorialLog NO_CACHE_FACTORIAL_LOG;
+
+    static {
+        // Create without a cache.
+        NO_CACHE_FACTORIAL_LOG = FactorialLog.create();
+    }
+
+    /** Exponential. */
+    private final ContinuousSampler exponential;
+    /** Gaussian. */
+    private final ContinuousSampler gaussian;
+    /** Local class to compute {@code log(n!)}. This may have cached values. */
+    private final InternalUtils.FactorialLog factorialLog;
+ 
+    // Working values
+    private final double lambda;
+    private final double lambdaFractional;
+    private final double logLambda;
+    private final double logLambdaFactorial;
+    private final double delta;
+    private final double halfDelta;
+    private final double twolpd;
+    private final double p1;
+    private final double p2;
+    private final double c1;
+
+    /** The internal Poisson sampler for the lambda fraction. */
+    private final DiscreteSampler smallMeanPoissonSampler;
+
+    /**
+     * @param rng  Generator of uniformly distributed random numbers.
+     * @param mean Mean.
+     * @throws IllegalArgumentException if {@code mean <= 0}.
+     */
+    public LargeMeanPoissonSampler(UniformRandomProvider rng, 
+    		                       double mean) {
+        super(rng);
+        if (mean <= 0) {
+            throw new IllegalArgumentException(mean + " <= " + 0);
+        }
+        
+        gaussian = new ZigguratNormalizedGaussianSampler(rng);
+        exponential = new AhrensDieterExponentialSampler(rng, 1);
+        // Plain constructor uses the uncached function.
+        factorialLog = NO_CACHE_FACTORIAL_LOG;
+
+        // Cache values used in the algorithm
+        lambda = Math.floor(mean);
+        lambdaFractional = mean - lambda;
+        logLambda = Math.log(lambda);
+        logLambdaFactorial = factorialLog((int) lambda);
+        delta = Math.sqrt(lambda * Math.log(32 * lambda / Math.PI + 1));
+        halfDelta = delta / 2;
+        twolpd = 2 * lambda + delta;
+        c1 = 1 / (8 * lambda);
+        final double a1 = Math.sqrt(Math.PI * twolpd) * Math.exp(c1);
+        final double a2 = (twolpd / delta) * Math.exp(-delta * (1 + delta) / twolpd);
+        final double aSum = a1 + a2 + 1;
+        p1 = a1 / aSum;
+        p2 = a2 / aSum;
+
+        // The algorithm requires a Poisson sample from the remaining lambda fraction.
+        smallMeanPoissonSampler = (lambdaFractional < Double.MIN_VALUE) ?
+            null : // Not used.
+            new SmallMeanPoissonSampler(rng, lambdaFractional);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public int sample() {
+
+        final int y2 = (smallMeanPoissonSampler == null) ? 
+            0 : // No lambda fraction
+            smallMeanPoissonSampler.sample();
+        
+        double x = 0;
+        double y = 0;
+        double v = 0;
+        int a = 0;
+        double t = 0;
+        double qr = 0;
+        double qa = 0;
+        while (true) {
+            final double u = nextDouble();
+            if (u <= p1) {
+                final double n = gaussian.sample();
+                x = n * Math.sqrt(lambda + halfDelta) - 0.5d;
+                if (x > delta || x < -lambda) {
+                    continue;
+                }
+                y = x < 0 ? Math.floor(x) : Math.ceil(x);
+                final double e = exponential.sample();
+                v = -e - 0.5 * n * n + c1;
+            } else {
+                if (u > p1 + p2) {
+                    y = lambda;
+                    break;
+                }
+                x = delta + (twolpd / delta) * exponential.sample();
+                y = Math.ceil(x);
+                v = -exponential.sample() - delta * (x + 1) / twolpd;
+            }
+            a = x < 0 ? 1 : 0;
+            t = y * (y + 1) / (2 * lambda);
+            if (v < -t && a == 0) {
+                y = lambda + y;
+                break;
+            }
+            qr = t * ((2 * y + 1) / (6 * lambda) - 1);
+            qa = qr - (t * t) / (3 * (lambda + a * (y + 1)));
+            if (v < qa) {
+                y = lambda + y;
+                break;
+            }
+            if (v > qr) {
+                continue;
+            }
+            if (v < y * logLambda - factorialLog((int) (y + lambda)) + logLambdaFactorial) {
+                y = lambda + y;
+                break;
+            }
+        }
+        
+        return (int) Math.min(y2 + (long) y, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Compute the natural logarithm of the factorial of {@code n}.
+     *
+     * @param n Argument.
+     * @return {@code log(n!)}
+     * @throws IllegalArgumentException if {@code n < 0}.
+     */
+    private final double factorialLog(int n) {
+        return factorialLog.value(n);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "Large Mean Poisson deviate [" + super.toString() + "]";
+    }
+}

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
@@ -31,7 +31,7 @@ import org.apache.commons.rng.sampling.distribution.InternalUtils.FactorialLog;
  *   </blockquote>
  *  </li>
  * </ul>
- * 
+ *
  * This sampler is suitable for {@code mean >= 40}.
  */
 public class LargeMeanPoissonSampler
@@ -39,7 +39,7 @@ public class LargeMeanPoissonSampler
     implements DiscreteSampler {
 
     /** Class to compute {@code log(n!)}. This has no cached values. */
-    static private final InternalUtils.FactorialLog NO_CACHE_FACTORIAL_LOG;
+    private static final InternalUtils.FactorialLog NO_CACHE_FACTORIAL_LOG;
 
     static {
         // Create without a cache.
@@ -52,17 +52,40 @@ public class LargeMeanPoissonSampler
     private final ContinuousSampler gaussian;
     /** Local class to compute {@code log(n!)}. This may have cached values. */
     private final InternalUtils.FactorialLog factorialLog;
- 
+
     // Working values
+
+    /** Algorithm constant: {@code Math.floor(mean)}. */
     private final double lambda;
+    /** Algorithm constant: {@code mean - lambda}. */
     private final double lambdaFractional;
+    /** Algorithm constant: {@code Math.log(lambda)}. */
     private final double logLambda;
+    /** Algorithm constant: {@code factorialLog((int) lambda)}. */
     private final double logLambdaFactorial;
+    /** Algorithm constant: {@code Math.sqrt(lambda * Math.log(32 * lambda / Math.PI + 1))}. */
     private final double delta;
+    /** Algorithm constant: {@code delta / 2}. */
     private final double halfDelta;
+    /** Algorithm constant: {@code 2 * lambda + delta}. */
     private final double twolpd;
+    /**
+     * Algorithm constant: {@code a1 / aSum} with
+     * <ul>
+     *  <li>{@code a1 = Math.sqrt(Math.PI * twolpd) * Math.exp(c1)}</li>
+     *  <li>{@code aSum = a1 + a2 + 1}</li>
+     * </ul>
+     */
     private final double p1;
+    /**
+     * Algorithm constant: {@code a1 / aSum} with
+     * <ul>
+     *  <li>{@code a2 = (twolpd / delta) * Math.exp(-delta * (1 + delta) / twolpd)}</li>
+     *  <li>{@code aSum = a1 + a2 + 1}</li>
+     * </ul>
+     */
     private final double p2;
+    /** Algorithm constant: {@code 1 / (8 * lambda)}. */
     private final double c1;
 
     /** The internal Poisson sampler for the lambda fraction. */
@@ -73,13 +96,13 @@ public class LargeMeanPoissonSampler
      * @param mean Mean.
      * @throws IllegalArgumentException if {@code mean <= 0}.
      */
-    public LargeMeanPoissonSampler(UniformRandomProvider rng, 
-    		                       double mean) {
+    public LargeMeanPoissonSampler(UniformRandomProvider rng,
+                                   double mean) {
         super(rng);
         if (mean <= 0) {
             throw new IllegalArgumentException(mean + " <= " + 0);
         }
-        
+
         gaussian = new ZigguratNormalizedGaussianSampler(rng);
         exponential = new AhrensDieterExponentialSampler(rng, 1);
         // Plain constructor uses the uncached function.
@@ -105,15 +128,15 @@ public class LargeMeanPoissonSampler
             null : // Not used.
             new SmallMeanPoissonSampler(rng, lambdaFractional);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public int sample() {
 
-        final int y2 = (smallMeanPoissonSampler == null) ? 
+        final int y2 = (smallMeanPoissonSampler == null) ?
             0 : // No lambda fraction
             smallMeanPoissonSampler.sample();
-        
+
         double x = 0;
         double y = 0;
         double v = 0;
@@ -161,7 +184,7 @@ public class LargeMeanPoissonSampler
                 break;
             }
         }
-        
+
         return (int) Math.min(y2 + (long) y, Integer.MAX_VALUE);
     }
 
@@ -172,7 +195,7 @@ public class LargeMeanPoissonSampler
      * @return {@code log(n!)}
      * @throws IllegalArgumentException if {@code n < 0}.
      */
-    private final double factorialLog(int n) {
+    private double factorialLog(int n) {
         return factorialLog.value(n);
     }
 

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
@@ -27,46 +27,59 @@ import org.apache.commons.rng.UniformRandomProvider;
  *   described <a href="http://mathaa.epfl.ch/cours/PMMI2001/interactive/rng7.htm">here</a>.
  *   The Poisson process (and hence, the returned value) is bounded by 1000 * mean.
  *  </li>
- *  <li>
- *   For large means, we use the rejection algorithm described in
- *   <blockquote>
- *    Devroye, Luc. (1981). <i>The Computer Generation of Poisson Random Variables</i><br>
- *    <strong>Computing</strong> vol. 26 pp. 197-207.
- *   </blockquote>
- *  </li>
  * </ul>
+ * 
+ * This sampler is suitable for {@code mean < 40}.
  */
-public class PoissonSampler
+public class SmallMeanPoissonSampler
+    extends SamplerBase
     implements DiscreteSampler {
 
-    /** Value for switching sampling algorithm. */
-    static final double PIVOT = 40;
-    /** The internal Poisson sampler. */
-    private final DiscreteSampler poissonSampler;
+    /** 
+     * Pre-compute {@code Math.exp(-mean)}. 
+     * Note: This is the probability of the Poisson sample {@code P(n=0)}.
+     */
+    private final double p0;
+    /** Pre-compute {@code 1000 * mean} as the upper limit of the sample. */
+    private final int limit;
 
     /**
      * @param rng  Generator of uniformly distributed random numbers.
      * @param mean Mean.
      * @throws IllegalArgumentException if {@code mean <= 0}.
      */
-    public PoissonSampler(UniformRandomProvider rng,
-                          double mean) {
-        // Delegate all work to specialised samplers.
-        // These should check the input arguments.
-        poissonSampler = mean < PIVOT ?
-            new SmallMeanPoissonSampler(rng, mean) :
-            new LargeMeanPoissonSampler(rng, mean);
+    public SmallMeanPoissonSampler(UniformRandomProvider rng,
+                                   double mean) {
+        super(rng);
+        if (mean <= 0) {
+            throw new IllegalArgumentException(mean + " <= " + 0);
+        }
+        
+        p0 = Math.exp(-mean);
+        // The returned sample is bounded by 1000 * mean or Integer.MAX_VALUE
+        limit = (int) Math.ceil(Math.min(1000 * mean, Integer.MAX_VALUE));
     }
 
     /** {@inheritDoc} */
     @Override
     public int sample() {
-        return poissonSampler.sample();
-    }
+        int n = 0;
+        double r = 1;
 
+        while (n < limit) {
+            r *= nextDouble();
+            if (r >= p0) {
+                n++;
+            } else {
+                break;
+            }
+        }
+        return n;
+    }
+    
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return "Poisson deviate [" + super.toString() + "]";
+        return "Small Mean Poisson deviate [" + super.toString() + "]";
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
@@ -28,15 +28,15 @@ import org.apache.commons.rng.UniformRandomProvider;
  *   The Poisson process (and hence, the returned value) is bounded by 1000 * mean.
  *  </li>
  * </ul>
- * 
+ *
  * This sampler is suitable for {@code mean < 40}.
  */
 public class SmallMeanPoissonSampler
     extends SamplerBase
     implements DiscreteSampler {
 
-    /** 
-     * Pre-compute {@code Math.exp(-mean)}. 
+    /**
+     * Pre-compute {@code Math.exp(-mean)}.
      * Note: This is the probability of the Poisson sample {@code P(n=0)}.
      */
     private final double p0;
@@ -54,7 +54,7 @@ public class SmallMeanPoissonSampler
         if (mean <= 0) {
             throw new IllegalArgumentException(mean + " <= " + 0);
         }
-        
+
         p0 = Math.exp(-mean);
         // The returned sample is bounded by 1000 * mean or Integer.MAX_VALUE
         limit = (int) Math.ceil(Math.min(1000 * mean, Integer.MAX_VALUE));
@@ -76,7 +76,7 @@ public class SmallMeanPoissonSampler
         }
         return n;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.rng.sampling.distribution;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,16 +108,28 @@ public class DiscreteSamplersList {
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(meanPoisson),
                 MathArrays.sequence(10, 0, 1),
                 new PoissonSampler(RandomSource.create(RandomSource.KISS), meanPoisson));
+            // Dedicated small mean poisson sampler
+            add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(meanPoisson),
+                MathArrays.sequence(10, 0, 1),
+                new SmallMeanPoissonSampler(RandomSource.create(RandomSource.KISS), meanPoisson));
             // Poisson (40 < mean < 80).
             final double largeMeanPoisson = 67.89;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(largeMeanPoisson),
                 MathArrays.sequence(50, (int) (largeMeanPoisson - 25), 1),
                 new PoissonSampler(RandomSource.create(RandomSource.SPLIT_MIX_64), largeMeanPoisson));
+            // Dedicated large mean poisson sampler
+            add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(largeMeanPoisson),
+                MathArrays.sequence(50, (int) (largeMeanPoisson - 25), 1),
+                new LargeMeanPoissonSampler(RandomSource.create(RandomSource.SPLIT_MIX_64), largeMeanPoisson));
             // Poisson (mean >> 40).
             final double veryLargeMeanPoisson = 543.21;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(veryLargeMeanPoisson),
                 MathArrays.sequence(100, (int) (veryLargeMeanPoisson - 50), 1),
                 new PoissonSampler(RandomSource.create(RandomSource.SPLIT_MIX_64), veryLargeMeanPoisson));
+            // Dedicated large mean poisson sampler
+            add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(veryLargeMeanPoisson),
+                MathArrays.sequence(100, (int) (veryLargeMeanPoisson - 50), 1),
+                new LargeMeanPoissonSampler(RandomSource.create(RandomSource.SPLIT_MIX_64), veryLargeMeanPoisson));
         } catch (Exception e) {
             System.err.println("Unexpected exception while creating the list of samplers: " + e);
             e.printStackTrace(System.err);


### PR DESCRIPTION
The algorithms for small mean and large mean have been separated into
dedicated classes. Caching of constants used in the algorithm has been
used to increase speed.

Note: I have run `mvn clean verify` within the `commons-rng-sampling` module but the randomness of the `ContinuousSamplerParametricTest` causes it to fail on different distributions. I have seen failures on:

- Box-Muller Gaussian deviate
- org.apache.commons.math3.distribution.LevyDistribution (inverse method)

These are unrelated to the PoissonSampler.

I ran `mvn clean verify -DskipTests=true` and that had no errors. 

No checkstyle errors in the project files modified in this PR.