### PR TITLE
Improvement rng 50

### DIFF
--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
@@ -190,7 +190,7 @@ public class LargeMeanPoissonSampler
         }
 
         /**
-         * Get the lambda value for the state. Equals to {@code floor(mean)}.
+         * Get the lambda value for the state. Equal to {@code floor(mean)}.
          * @return {@code floor(mean)}
          */
         int getLambda() {

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSampler.java
@@ -39,8 +39,11 @@ import org.apache.commons.rng.UniformRandomProvider;
 public class PoissonSampler
     implements DiscreteSampler {
 
-    /** Value for switching sampling algorithm. */
-    private static final double PIVOT = 40;
+    /**
+     * Value for switching sampling algorithm.
+     * Package scope for the {@link PoissonSamplerCache}.
+     */
+    static final double PIVOT = 40;
     /** The internal Poisson sampler. */
     private final DiscreteSampler poissonSampler;
 

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCache.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCache.java
@@ -289,7 +289,6 @@ public class PoissonSamplerCache {
      * @param minMean The minimum mean covered by the cache.
      * @param maxMean The maximum mean covered by the cache.
      * @throws IllegalArgumentException if {@code maxMean < minMean}
-     * @throws IllegalStateException if the cache values cannot be reused
      * @return the poisson sampler cache
      */
     public PoissonSamplerCache withRange(double minMean,
@@ -330,14 +329,11 @@ public class PoissonSamplerCache {
         while (currentIndex < values.length() && nextIndex < states.length) {
             LargeMeanPoissonSamplerState state = values.get(currentIndex);
             if (state != null) {
-                //  Validate
-                int expected = nextMinN + nextIndex;
-                int actual = state.getLambda();
-                if (expected != actual) {
-                    throw new IllegalStateException(String.format(
-                        "Unexpected lambda value: expected <%d>, found <%d>",
-                            expected, actual));
-                }
+                // Validate with assert
+                assert nextMinN + nextIndex == state.getLambda() :
+                    String.format("Unexpected lambda value: expected <%d>, found <%d>",
+                                  nextMinN + nextIndex,
+                                  state.getLambda());
                 states[nextIndex] = state;
             }
             currentIndex++;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCache.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCache.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.distribution.PoissonSampler;
+import org.apache.commons.rng.sampling.distribution.LargeMeanPoissonSampler.LargeMeanPoissonSamplerState;
+
+/**
+ * Create a sampler for the
+ * <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson
+ * distribution</a> using a cache to minimise construction cost.
+ * <p>
+ * The cache will return a sampler equivalent to
+ * {@link org.apache.commons.rng.sampling.distribution#PoissonSampler(UniformRandomProvider, double)}.
+ * <p>
+ * The cache allows the {@link PoissonSampler} construction cost to be minimised
+ * for low size Poisson samples. The cache is advantageous under the following
+ * conditions:
+ * <ul>
+ * <li>The mean of the Poisson distribution falls within a known range.</li>
+ * <li>The sample size to be made with the <strong>same</strong> sampler is
+ * small.</li>
+ * </ul>
+ * <p>
+ * If the sample size to be made with the <strong>same</strong> sampler is large
+ * then the construction cost is minimal compared to the sampling time.
+ * <p>
+ * Performance improvement is dependent on the speed of the
+ * {@link UniformRandomProvider}. A fast provider can obtain a two-fold speed
+ * improvement for a single-use Poisson sampler.
+ * <p>
+ * The cache is thread safe. Note that concurrent threads using the cache
+ * must ensure a thread safe {@link UniformRandomProvider} is used when creating
+ * samplers, e.g. a unique sampler per thread.
+ */
+public class PoissonSamplerCache {
+
+    /**
+     * The minimum N covered by the cache where
+     * {@code N = (int)Math.floor(mean)}.
+     */
+    private final int minN;
+    /**
+     * The maximum N covered by the cache where
+     * {@code N = (int)Math.floor(mean)}.
+     */
+    private final int maxN;
+    /** The cache of states between {@link minN} and {@link maxN}. */
+    private final AtomicReferenceArray<LargeMeanPoissonSamplerState> values;
+
+    /**
+     * @param minMean The minimum mean covered by the cache.
+     * @param maxMean The maximum mean covered by the cache.
+     * @throws IllegalArgumentException if {@code maxMean < minMean}
+     */
+    public PoissonSamplerCache(double minMean,
+                               double maxMean) {
+
+        // Although a mean of 0 is invalid for a Poisson sampler this case
+        // is handled to make the cache user friendly. Any low means will
+        // be handled by the SmallMeanPoissonSampler and not cached.
+        if (minMean < 0) {
+            minMean = 0;
+        }
+        checkMeanRange(minMean, maxMean);
+
+        // The cache can only be used for the LargeMeanPoissonSampler.
+        if (maxMean < PoissonSampler.PIVOT) {
+            // The upper limit is too small so no cache will be used.
+            // This class will just construct new samplers.
+            minN = 0;
+            maxN = 0;
+            values = null;
+        } else {
+            // Convert the mean into integers.
+            // Note the minimum is clipped to the algorithm switch point.
+            this.minN = (int) Math.floor(Math.max(minMean, PoissonSampler.PIVOT));
+            this.maxN = (int) Math.floor(maxMean);
+            values = new AtomicReferenceArray<LargeMeanPoissonSamplerState>(
+                    maxN - minN + 1);
+        }
+    }
+
+    /**
+     * @param minN   The minimum N covered by the cache where {@code N = (int)Math.floor(mean)}.
+     * @param maxN   The maximum N covered by the cache where {@code N = (int)Math.floor(mean)}.
+     * @param states The precomputed states.
+     */
+    private PoissonSamplerCache(int minN,
+                                int maxN,
+                                LargeMeanPoissonSamplerState[] states) {
+        this.minN = minN;
+        this.maxN = maxN;
+        this.values = new AtomicReferenceArray<LargeMeanPoissonSamplerState>(states);
+    }
+
+    /**
+     * Check the mean range.
+     *
+     * @param minMean The minimum mean covered by the cache.
+     * @param maxMean The maximum mean covered by the cache.
+     * @throws IllegalArgumentException if {@code maxMean < minMean}
+     */
+    private static void checkMeanRange(double minMean, double maxMean)
+    {
+        // Allow minMean == maxMean so that the cache can be used across
+        // concurrent threads to create samplers with distinct RNGs and the
+        // same mean.
+        if (maxMean < minMean) {
+            throw new IllegalArgumentException(
+                    "Max mean: " + maxMean + " < " + minMean);
+        }
+    }
+
+    /**
+     * Creates a Poisson sampler. The returned sampler will function exactly the
+     * same as
+     * {@link org.apache.commons.rng.sampling.distribution#PoissonSampler(UniformRandomProvider, double)}.
+     * <p>
+     * A value of {@code mean} outside the range of the cache is valid.
+     *
+     * @param rng  Generator of uniformly distributed random numbers.
+     * @param mean Mean.
+     * @return A Poisson sampler
+     * @throws IllegalArgumentException if {@code mean <= 0}.
+     */
+    public DiscreteSampler getPoissonSampler(UniformRandomProvider rng,
+                                             double mean) {
+        // Ensure the same functionality as the PoissonSampler by
+        // using a SmallMeanPoissonSampler under the switch point.
+        if (mean < PoissonSampler.PIVOT) {
+            return new SmallMeanPoissonSampler(rng, mean);
+        }
+
+        // Convert the mean into an integer.
+        final int n = (int) Math.floor(mean);
+        // Check maxN first as the cache is likely to be used from min=0
+        if (n > maxN || n < minN) {
+            // Outside the range of the cache.
+            return new LargeMeanPoissonSampler(rng, mean);
+        }
+
+        // Look in the cache for a state that can be reused.
+        // Note: The cache is offset by minN.
+        final int index = n - minN;
+        // From the java.util.concurrent.atomic Javadoc:
+        // get has the memory effects of reading a volatile variable.
+        LargeMeanPoissonSamplerState state = values.get(index);
+        if (state == null) {
+            // Compute and store for reuse
+            state = LargeMeanPoissonSamplerState.create(n);
+            // Set this but do not worry about strict ordering
+            // as would be imposed for .set(int, Object) since any later
+            // objects that may be written by other threads will be the same.
+            // Allows concurrent threads to set the state without
+            // excess synchronisation over the exact object that is stored.
+            //
+            // From the java.util.concurrent.atomic Javadoc:
+            // lazySet has the memory effects of writing (assigning) a volatile
+            // variable except that it permits reorderings with subsequent (but
+            // not previous) memory actions that do not themselves impose
+            // reordering constraints with ordinary non-volatile writes.
+            values.lazySet(index, state);
+        }
+        // Compute the remaining fraction of the mean
+        final double lambdaFractional = mean - n;
+        return new LargeMeanPoissonSampler(rng, state, lambdaFractional);
+    }
+
+    /**
+     * Check if the mean is within the range where the cache can minimise the
+     * construction cost of the {@link PoissonSampler}.
+     *
+     * @param mean
+     *            the mean
+     * @return true, if within the cache range
+     */
+    public boolean withinRange(double mean) {
+        if (mean < PoissonSampler.PIVOT) {
+            // Construction is optimal
+            return true;
+        }
+        // Convert the mean into an integer.
+        final int n = (int) Math.floor(mean);
+        return n <= maxN && n >= minN;
+    }
+
+    /**
+     * Checks if the cache covers a valid range of mean values.
+     * <p>
+     * Note that the cache is only valid for one of the Poisson sampling
+     * algorithms. In the instance that a range was requested that was too
+     * low then there is nothing to cache and this functions returns
+     * {@code false}.
+     * <p>
+     * The cache can still be used to create a {@link PoissonSampler} using
+     * {@link #getPoissonSampler(UniformRandomProvider, double)}.
+     * <p>
+     * This method can be used to determine if the cache has value.
+     *
+     * @return true, if the cache covers a range of mean values
+     */
+    public boolean isValidRange() {
+        return values != null;
+    }
+
+    /**
+     * Gets the minimum mean covered by the cache.
+     * <p>
+     * This value is the inclusive lower bound and is equal to
+     * the lowest integer-valued mean that is covered by the cache.
+     * <p>
+     * Note that this value may not match the value passed to the constructor
+     * due to the following reasons:
+     * <ul>
+     *  <li>At small mean values a different algorithm is used for Poisson
+     *      sampling and the cache is unnecessary.</li>
+     *  <li>The minimum is always an integer so may be below the constructor
+     *      minimum mean.</li>
+     * </ul>
+     * <p>
+     * If {@link #isValidRange()} returns {@code true} the cache will store
+     * state to reduce construction cost of samplers in
+     * the range {@link #getMinMean()} inclusive to {@link #getMaxMean()}
+     * inclusive. Otherwise this method returns 0;
+     *
+     * @return The minimum mean covered by the cache.
+     */
+    public double getMinMean()
+    {
+        return minN;
+    }
+
+    /**
+     * Gets the maximum mean covered by the cache.
+     * <p>
+     * This value is the inclusive upper bound and is equal to
+     * the double value below the first integer-valued mean that is
+     * above range covered by the cache.
+     * <p>
+     * Note that this value may not match the value passed to the constructor
+     * due to the following reasons:
+     * <ul>
+     *  <li>At small mean values a different algorithm is used for Poisson
+     *      sampling and the cache is unnecessary.</li>
+     *  <li>The maximum is always the double value below an integer so
+     *      may be above the constructor maximum mean.</li>
+     * </ul>
+     * <p>
+     * If {@link #isValidRange()} returns {@code true} the cache will store
+     * state to reduce construction cost of samplers in
+     * the range {@link #getMinMean()} inclusive to {@link #getMaxMean()}
+     * inclusive. Otherwise this method returns 0;
+     *
+     * @return The maximum mean covered by the cache.
+     */
+    public double getMaxMean()
+    {
+        if (isValidRange()) {
+            return Math.nextAfter(maxN + 1.0, -1);
+        }
+        return 0;
+    }
+
+    /**
+     * Create a new {@link PoissonSamplerCache} with the given range
+     * reusing the current cache values.
+     * <p>
+     * This will create a new object even if the range is smaller or the
+     * same as the current cache.
+     *
+     * @param minMean The minimum mean covered by the cache.
+     * @param maxMean The maximum mean covered by the cache.
+     * @throws IllegalArgumentException if {@code maxMean < minMean}
+     * @throws IllegalStateException if the cache values cannot be reused
+     * @return the poisson sampler cache
+     */
+    public PoissonSamplerCache withRange(double minMean,
+                                         double maxMean) {
+        if (values == null) {
+            // Nothing to reuse
+            return new PoissonSamplerCache(minMean, maxMean);
+        }
+        if (minMean < 0) {
+            minMean = 0;
+        }
+        checkMeanRange(minMean, maxMean);
+
+        // The cache can only be used for the LargeMeanPoissonSampler.
+        if (maxMean < PoissonSampler.PIVOT) {
+            return new PoissonSamplerCache(0, 0);
+        }
+
+        // Convert the mean into integers.
+        // Note the minimum is clipped to the algorithm switch point.
+        int nextMinN = (int) Math.floor(Math.max(minMean, PoissonSampler.PIVOT));
+        int nextMaxN = (int) Math.floor(maxMean);
+        LargeMeanPoissonSamplerState[] states =
+                new LargeMeanPoissonSamplerState[nextMaxN - nextMinN + 1];
+
+        // Preserve values from the current array to the next
+        int currentIndex;
+        int nextIndex;
+        if (this.minN <= nextMinN) {
+            // The current array starts before the next array
+            currentIndex = nextMinN - this.minN;
+            nextIndex = 0;
+        } else {
+            // The next array starts before the current array
+            currentIndex = 0;
+            nextIndex = this.minN - nextMinN;
+        }
+        while (currentIndex < values.length() && nextIndex < states.length) {
+            LargeMeanPoissonSamplerState state = values.get(currentIndex);
+            if (state != null) {
+                //  Validate
+                int expected = nextMinN + nextIndex;
+                int actual = state.getLambda();
+                if (expected != actual) {
+                    throw new IllegalStateException(String.format(
+                        "Unexpected lambda value: expected <%d>, found <%d>",
+                            expected, actual));
+                }
+                states[nextIndex] = state;
+            }
+            currentIndex++;
+            nextIndex++;
+        }
+
+        return new PoissonSamplerCache(nextMinN, nextMaxN, states);
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.rng.RandomProviderState;
+import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.sampling.distribution.LargeMeanPoissonSampler.LargeMeanPoissonSamplerState;
+import org.apache.commons.rng.simple.RandomSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This test checks the {@link LargeMeanPoissonSampler} using the 
+ * {@link LargeMeanPoissonSamplerState}.
+ */
+public class LargeMeanPoissonSamplerTest {
+
+    // Edge cases for construction
+
+    /**
+     * Test the constructor with a bad mean.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorThrowsWithZeroMean() {
+        final RestorableUniformRandomProvider rng =
+                RandomSource.create(RandomSource.SPLIT_MIX_64);
+        @SuppressWarnings("unused")
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, 0);
+    }
+
+    /**
+     * Test the state cannot be created with a negative n.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testStateCreationThrowsWithNegativeN() {
+        @SuppressWarnings("unused")
+        LargeMeanPoissonSamplerState state = LargeMeanPoissonSamplerState.create(-1);
+    }
+
+    /**
+     * Test the constructor with a negative fractional mean.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorThrowsWithNegativeFractionalMean() {
+        final RestorableUniformRandomProvider rng =
+                RandomSource.create(RandomSource.SPLIT_MIX_64);
+        LargeMeanPoissonSamplerState state = LargeMeanPoissonSamplerState.create(0);
+        @SuppressWarnings("unused")
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, -0.1);
+    }
+
+    /**
+     * Test the constructor with a non-fractional mean.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorThrowsWithNonFractionalMean() {
+        final RestorableUniformRandomProvider rng =
+                RandomSource.create(RandomSource.SPLIT_MIX_64);
+        LargeMeanPoissonSamplerState state = LargeMeanPoissonSamplerState.create(0);
+        @SuppressWarnings("unused")
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, 1.1);
+    }
+
+    /**
+     * Test the constructor with fractional mean of 1.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorThrowsWithFractionalMeanOne() {
+        final RestorableUniformRandomProvider rng =
+                RandomSource.create(RandomSource.SPLIT_MIX_64);
+        LargeMeanPoissonSamplerState state = LargeMeanPoissonSamplerState.create(0);
+        @SuppressWarnings("unused")
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, 1);
+    }
+
+    // Sampling tests
+
+    /**
+     * Test the {@link LargeMeanPoissonSampler} returns the same samples when it
+     * is created using the {@link LargeMeanPoissonSamplerState}.
+     */
+    @Test
+    public void testCanComputeSameSamplesWhenConstructedWithState() {
+        // Two identical RNGs
+        final RestorableUniformRandomProvider rng1 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+        final RandomProviderState state = rng1.saveState();
+        final RestorableUniformRandomProvider rng2 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+        rng2.restoreState(state);
+
+        // The sampler is suitable for mean > 40
+        for (int i = 40; i < 44; i++) {
+            // Test integer mean (no SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, i);
+            // Test non-integer mean (SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, i + 0.5);
+        }
+    }
+
+    /**
+     * Test poisson samples are the same from the {@link PoissonSampler}
+     * and {@link PoissonSamplerCache}. The random providers must be
+     * identical (including state).
+     *
+     * @param rng1  the first random provider
+     * @param rng2  the second random provider
+     * @param cache the cache
+     * @param mean  the mean
+     */
+    private static void testPoissonSamples(
+            final RestorableUniformRandomProvider rng1,
+            final RestorableUniformRandomProvider rng2,
+            double mean) {
+        final DiscreteSampler s1 = new LargeMeanPoissonSampler(rng1, mean);
+        int n = (int) Math.floor(mean);
+        double lambdaFractional = mean - n;
+        LargeMeanPoissonSamplerState state = LargeMeanPoissonSamplerState.create(n);
+        final DiscreteSampler s2 = new LargeMeanPoissonSampler(rng2, state, lambdaFractional);
+        for (int j = 0; j < 10; j++)
+            Assert.assertEquals(s1.sample(), s2.sample());
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.rng.RandomProviderState;
+import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This test checks the {@link PoissonSamplerCache} functions exactly like the
+ * constructor of the {@link PoissonSampler}, irrespective of the range
+ * covered by the cache.
+ */
+public class PoissonSamplerCacheTest {
+
+    // Set a range so that the SmallMeanPoissonSampler is also required.
+
+    /** The minimum of the range of the mean */
+    private final int minRange = (int) Math.floor(PoissonSampler.PIVOT - 2);
+    /** The maximum of the range of the mean */
+    private final int maxRange = (int) Math.floor(PoissonSampler.PIVOT + 6);
+    /** The mid-point of the range of the mean */
+    private final int midRange = (minRange + maxRange) / 2;
+
+    /**
+     * Test the cache can be created without a range that requires a cache.
+     * In this case the cache will be a pass through to the constructor
+     * of the SmallMeanPoissonSampler.
+     */
+    @Test
+    public void testConstructorWithNoCache() {
+        final double min = 0;
+        final double max = PoissonSampler.PIVOT - 2;
+        PoissonSamplerCache cache = createPoissonSamplerCache(min, max);
+        Assert.assertFalse(cache.isValidRange());
+        Assert.assertEquals(0, cache.getMinMean(), 0);
+        Assert.assertEquals(0, cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache can be created with a range of 1.
+     * In this case the cache will be valid for all mean values
+     * in the range {@code n <= mean < n+1}.
+     */
+    @Test
+    public void testConstructorWhenMaxEqualsMin() {
+        final double min = PoissonSampler.PIVOT + 2;
+        final double max = min;
+        PoissonSamplerCache cache = createPoissonSamplerCache(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(min, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+
+    /**
+     * Test the cache can be created with a range of 1.
+     * In this case the cache will be valid for all mean values
+     * in the range {@code n <= mean < n+1}.
+     */
+    @Test
+    public void testConstructorWhenMaxAboveMin() {
+        final double min = PoissonSampler.PIVOT + 2;
+        final double max = min + 10;
+        PoissonSamplerCache cache = createPoissonSamplerCache(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(min, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache requires a range with {@code max >= min}.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testConstructorThrowsWhenMaxIsLessThanMin() {
+        final double min = PoissonSampler.PIVOT;
+        final double max = Math.nextAfter(min, -1);
+        createPoissonSamplerCache(min, max);
+    }
+
+    /**
+     * Test the cache can be created without a range that requires a cache.
+     * In this case the cache will be a pass through to the constructor
+     * of the SmallMeanPoissonSampler.
+     */
+    @Test
+    public void testWithRangeConstructorWithNoCache() {
+        final double min = 0;
+        final double max = PoissonSampler.PIVOT - 2;
+        PoissonSamplerCache cache = createPoissonSamplerCache().withRange(min, max);
+        Assert.assertFalse(cache.isValidRange());
+        Assert.assertEquals(0, cache.getMinMean(), 0);
+        Assert.assertEquals(0, cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache can be created with a range of 1.
+     * In this case the cache will be valid for all mean values
+     * in the range {@code n <= mean < n+1}.
+     */
+    @Test
+    public void testWithRangeConstructorWhenMaxEqualsMin() {
+        final double min = PoissonSampler.PIVOT + 2;
+        final double max = min;
+        PoissonSamplerCache cache = createPoissonSamplerCache().withRange(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(min, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache can be created with a range of 1.
+     * In this case the cache will be valid for all mean values
+     * in the range {@code n <= mean < n+1}.
+     */
+    @Test
+    public void testWithRangeConstructorWhenMaxAboveMin() {
+        final double min = PoissonSampler.PIVOT + 2;
+        final double max = min + 10;
+        PoissonSamplerCache cache = createPoissonSamplerCache().withRange(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(min, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache requires a range with {@code max >= min}.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testWithRangeConstructorThrowsWhenMaxIsLessThanMin() {
+        final double min = PoissonSampler.PIVOT;
+        final double max = Math.nextAfter(min, -1);
+        createPoissonSamplerCache().withRange(min, max);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler when it
+     * covers the entire range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerWithFullRangeCache() {
+        checkComputeSameSamplesAsPoissonSampler(minRange,
+                                                maxRange);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler
+     * with no cache.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerWithNoCache() {
+        checkComputeSameSamplesAsPoissonSampler(0,
+                                                minRange - 2);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * partial cache covering the lower range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerWithPartialCacheCoveringLowerRange() {
+        checkComputeSameSamplesAsPoissonSampler(minRange,
+                                                midRange);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * partial cache covering the upper range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerWithPartialCacheCoveringUpperRange() {
+        checkComputeSameSamplesAsPoissonSampler(midRange,
+                                                maxRange);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * cache above the upper range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerWithCacheAboveTheUpperRange() {
+        checkComputeSameSamplesAsPoissonSampler(maxRange + 10,
+                                                maxRange + 20);
+    }
+
+    /**
+     * Check poisson samples are the same from the {@link PoissonSampler}
+     * and {@link PoissonSamplerCache}.
+     *
+     * @param minMean the min mean of the cache
+     * @param maxMean the max mean of the cache
+     */
+    private void checkComputeSameSamplesAsPoissonSampler(int minMean,
+                                                         int maxMean) {
+        // Two identical RNGs
+        final RestorableUniformRandomProvider rng1 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+        final RandomProviderState state = rng1.saveState();
+        final RestorableUniformRandomProvider rng2 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+        rng2.restoreState(state);
+
+        // Create the cache with the given range
+        final PoissonSamplerCache cache = 
+                createPoissonSamplerCache(minMean, maxMean);
+        // Test all means in the test range (which may be different
+        // from the cache range).
+        for (int i = minRange; i <= maxRange; i++) {
+            // Test integer mean (no SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, cache, i);
+            // Test non-integer mean (SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, cache, i + 0.5);
+        }
+    }
+
+    /**
+     * Creates the poisson sampler cache.
+     *
+     * @param minMean the min mean
+     * @param maxMean the max mean
+     * @return the poisson sampler cache
+     */
+    private PoissonSamplerCache createPoissonSamplerCache(double minMean, 
+                                                          double maxMean)
+    {
+        return new PoissonSamplerCache(minMean, maxMean);
+    }
+
+
+    /**
+     * Creates a poisson sampler cache that will have a cache range
+     *
+     * @return the poisson sampler cache
+     */
+    private PoissonSamplerCache createPoissonSamplerCache()
+    {
+        return new PoissonSamplerCache(PoissonSampler.PIVOT, 
+                                       PoissonSampler.PIVOT + 10);
+    }
+    
+    /**
+     * Test poisson samples are the same from the {@link PoissonSampler}
+     * and {@link PoissonSamplerCache}. The random providers must be
+     * identical (including state).
+     *
+     * @param rng1  the first random provider
+     * @param rng2  the second random provider
+     * @param cache the cache
+     * @param mean  the mean
+     */
+    private static void testPoissonSamples(
+            final RestorableUniformRandomProvider rng1,
+            final RestorableUniformRandomProvider rng2,
+            PoissonSamplerCache cache,
+            double mean) {
+        final DiscreteSampler s1 = new PoissonSampler(rng1, mean);
+        final DiscreteSampler s2 = cache.getPoissonSampler(rng2, mean);
+        for (int j = 0; j < 10; j++)
+            Assert.assertEquals(s1.sample(), s2.sample());
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * a new cache reusing the entire range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheEntireRange() {
+        checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
+                                                            maxRange,
+                                                            midRange,
+                                                            maxRange);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * a new cache reusing none of the range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheNoRange() {
+        checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
+                                                            maxRange,
+                                                            maxRange + 10,
+                                                            maxRange + 20);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * a new cache reusing none of the range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheLowerRange() {
+        checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
+                                                            maxRange,
+                                                            minRange,
+                                                            midRange);
+    }
+
+    /**
+     * Test the cache returns the same samples as the PoissonSampler with
+     * a new cache reusing none of the range.
+     */
+    @Test
+    public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheUpperRange() {
+        checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
+                                                            maxRange,
+                                                            maxRange,
+                                                            maxRange + 5);
+    }
+
+    /**
+     * Check poisson samples are the same from the {@link PoissonSampler}
+     * and a {@link PoissonSamplerCache} created reusing values.
+     * <p>
+     * Note: This cannot check the cache values were reused but ensures 
+     * that a new cache created with a range functions correctly.
+     *
+     * @param minMean  the min mean of the cache
+     * @param maxMean  the max mean of the cache
+     * @param minMean2 the min mean of the second cache
+     * @param maxMean2 the max mean of the second cache
+     */
+    private void checkComputeSameSamplesAsPoissonSamplerReusingCache(int minMean,
+                                                                     int maxMean,
+                                                                     int minMean2,
+                                                                     int maxMean2) {
+        // Two identical RNGs
+        final RestorableUniformRandomProvider rng1 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+        final RandomProviderState state = rng1.saveState();
+        final RestorableUniformRandomProvider rng2 =
+                RandomSource.create(RandomSource.WELL_19937_C);
+
+        // Create the cache with the given range and fill it
+        final PoissonSamplerCache cache = 
+                createPoissonSamplerCache(minMean, maxMean);
+        // Test all means in the test range (which may be different
+        // from the cache range).
+        for (int i = minMean; i <= maxMean; i++) {
+            cache.getPoissonSampler(rng1, i);
+        }
+
+        final PoissonSamplerCache cache2 = cache.withRange(minMean2, maxMean2);
+        Assert.assertTrue("WithRange cache is the same object", cache != cache2);
+
+        rng1.restoreState(state);
+        rng2.restoreState(state);
+
+        // Test all means in the test range (which may be different
+        // from the cache range).
+        for (int i = minRange; i <= maxRange; i++) {
+            // Test integer mean (no SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, cache2, i);
+            // Test non-integer mean (SmallMeanPoissonSampler required)
+            testPoissonSamples(rng1, rng2, cache2, i + 0.5);
+        }
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
@@ -38,6 +38,8 @@ public class PoissonSamplerCacheTest {
     /** The mid-point of the range of the mean */
     private final int midRange = (minRange + maxRange) / 2;
 
+    // Edge cases for construction
+
     /**
      * Test the cache can be created without a range that requires a cache.
      * In this case the cache will be a pass through to the constructor
@@ -69,7 +71,6 @@ public class PoissonSamplerCacheTest {
                             cache.getMaxMean(), 0);
     }
 
-
     /**
      * Test the cache can be created with a range of 1.
      * In this case the cache will be valid for all mean values
@@ -94,6 +95,21 @@ public class PoissonSamplerCacheTest {
         final double min = PoissonSampler.PIVOT;
         final double max = Math.nextAfter(min, -1);
         createPoissonSamplerCache(min, max);
+    }
+
+    /**
+     * Test the cache can be created with a min range below 0.
+     * In this case the range is truncated to 0.
+     */
+    @Test
+    public void testConstructorWhenMinBelow0() {
+        final double min = -1;
+        final double max = PoissonSampler.PIVOT + 2;
+        PoissonSamplerCache cache = createPoissonSamplerCache(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(PoissonSampler.PIVOT, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
     }
 
     /**
@@ -152,6 +168,54 @@ public class PoissonSamplerCacheTest {
         final double max = Math.nextAfter(min, -1);
         createPoissonSamplerCache().withRange(min, max);
     }
+
+    /**
+     * Test the cache can be created with a min range below 0.
+     * In this case the range is truncated to 0.
+     */
+    @Test
+    public void testWithRangeConstructorWhenMinBelow0() {
+        final double min = -1;
+        final double max = PoissonSampler.PIVOT + 2;
+        PoissonSamplerCache cache = createPoissonSamplerCache().withRange(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(PoissonSampler.PIVOT, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the cache can be created from a cache with no capacity.
+     */
+    @Test
+    public void testWithRangeConstructorWhenCacheHasNoCapcity() {
+        final double min = PoissonSampler.PIVOT + 2;
+        final double max = min + 10;
+        PoissonSamplerCache cache = createPoissonSamplerCache(0, 0).withRange(min, max);
+        Assert.assertTrue(cache.isValidRange());
+        Assert.assertEquals(min, cache.getMinMean(), 0);
+        Assert.assertEquals(Math.nextAfter(Math.floor(max) + 1, -1),
+                            cache.getMaxMean(), 0);
+    }
+
+    /**
+     * Test the withRange function of the cache signals when construction
+     * cost is minimal.
+     */
+    @Test
+    public void testWithRange() {
+        final double min = PoissonSampler.PIVOT + 10;
+        final double max = PoissonSampler.PIVOT + 20;
+        PoissonSamplerCache cache = createPoissonSamplerCache(min, max);
+        // Under the pivot point is always within range
+        Assert.assertTrue(cache.withinRange(PoissonSampler.PIVOT - 1));
+        Assert.assertFalse(cache.withinRange(min - 1));
+        Assert.assertTrue(cache.withinRange(min));
+        Assert.assertTrue(cache.withinRange(max));
+        Assert.assertFalse(cache.withinRange(max + 10));
+    }
+
+    // Sampling tests
 
     /**
      * Test the cache returns the same samples as the PoissonSampler when it

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
@@ -305,25 +305,25 @@ public class PoissonSamplerCacheTest {
 
     /**
      * Test the cache returns the same samples as the PoissonSampler with
-     * a new cache reusing none of the range.
+     * a new cache reusing some of the lower range.
      */
     @Test
     public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheLowerRange() {
         checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
                                                             maxRange,
                                                             minRange,
-                                                            midRange);
+                                                            midRange + 1);
     }
 
     /**
      * Test the cache returns the same samples as the PoissonSampler with
-     * a new cache reusing none of the range.
+     * a new cache reusing some of the upper range.
      */
     @Test
     public void testCanComputeSameSamplesAsPoissonSamplerReusingCacheUpperRange() {
         checkComputeSameSamplesAsPoissonSamplerReusingCache(midRange,
                                                             maxRange,
-                                                            maxRange,
+                                                            maxRange - 1,
                                                             maxRange + 5);
     }
 


### PR DESCRIPTION
This adds the PoissonSamplerCache that can be used for faster construction of PoissonSamplers.

I've added tests for the edge conditions in the constructors and to ensure the sequence of Poisson samples is the same whether the cache is used to create the sampler or just the PoissonSampler constructor.

I have also added functionality to create a new cache from an existing one allowing the cached values to be recycled into a new range.