### PR TITLE
RNG-57: Cache values for provision of nextBoolean and nextInt

### DIFF
--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/IntProvider.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/IntProvider.java
@@ -28,11 +28,41 @@ public abstract class IntProvider
     extends BaseProvider
     implements RandomIntSource {
 
+    /**
+     * Provides a bit source for booleans.
+     *
+     * <p>A cached value from a call to {@link #nextInt()}.
+     */
+    private int booleanSource; // Initialised as 0
+
+    /**
+     * The bit mask of the boolean source to obtain the boolean bit.
+     *
+     * <p>The bit mask contains a single bit set. This begins at the least
+     * significant bit and is gradually shifted upwards until overflow to zero.
+     *
+     * <p>When zero a new boolean source should be created and the mask set to the
+     * least significant bit (i.e. 1).
+     */
+    private int booleanBitMask; // Initialised as 0
+
     /** {@inheritDoc} */
     @Override
     protected byte[] getStateInternal() {
+        final int[] state = new int[] { booleanSource,
+                                        booleanBitMask };
         return composeStateInternal(super.getStateInternal(),
-                                    new byte[0]); // No local state.
+                                    NumberFactory.makeByteArray(state));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, 8);
+        final int[] state = NumberFactory.makeIntArray(c[0]);
+        booleanSource  = state[0];
+        booleanBitMask = state[1];
+        super.setStateInternal(c[1]);
     }
 
     /** {@inheritDoc} */
@@ -44,7 +74,17 @@ public abstract class IntProvider
     /** {@inheritDoc} */
     @Override
     public boolean nextBoolean() {
-        return NumberFactory.makeBoolean(nextInt());
+        // Shift up. This will eventually overflow and become zero.
+        booleanBitMask <<= 1;
+        // The mask will either contain a single bit or none.
+        if (booleanBitMask == 0) {
+            // Set the least significant bit
+            booleanBitMask = 1;
+            // Get the next value
+            booleanSource = nextInt();
+        }
+        // Return if the bit is set
+        return (booleanSource & booleanBitMask) != 0;
     }
 
     /** {@inheritDoc} */

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/LongProvider.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/LongProvider.java
@@ -28,11 +28,57 @@ public abstract class LongProvider
     extends BaseProvider
     implements RandomLongSource {
 
+    /**
+     * Provides a bit source for booleans.
+     *
+     * <p>A cached value from a call to {@link #nextLong()}.
+     */
+    private long booleanSource; // Initialised as 0
+
+    /**
+     * The bit mask of the boolean source to obtain the boolean bit.
+     *
+     * <p>The bit mask contains a single bit set. This begins at the least
+     * significant bit and is gradually shifted upwards until overflow to zero.
+     *
+     * <p>When zero a new boolean source should be created and the mask set to the
+     * least significant bit (i.e. 1).
+     */
+    private long booleanBitMask; // Initialised as 0
+
+    /**
+     * Provides a source for ints.
+     *
+     * <p>A cached value from a call to {@link #nextLong()}.
+     */
+    private long intSource;
+
+    /** Flag to indicate an int source has been cached. */
+    private boolean cachedIntSource; // Initialised as false
+
     /** {@inheritDoc} */
     @Override
     protected byte[] getStateInternal() {
+        // Pack the boolean inefficiently as a long
+        final long[] state = new long[] { booleanSource,
+                                          booleanBitMask,
+                                          intSource,
+                                          cachedIntSource ? 1 : 0 };
         return composeStateInternal(super.getStateInternal(),
-                                    new byte[0]); // No local state.
+                                    NumberFactory.makeByteArray(state));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, 32);
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        booleanSource   = state[0];
+        booleanBitMask  = state[1];
+        intSource       = state[2];
+        // Non-zero is true
+        cachedIntSource = state[3] != 0;
+        super.setStateInternal(c[1]);
     }
 
     /** {@inheritDoc} */
@@ -44,7 +90,18 @@ public abstract class LongProvider
     /** {@inheritDoc} */
     @Override
     public int nextInt() {
-        return NumberFactory.makeInt(nextLong());
+        // Directly store and use the long value as a source for ints
+        if (cachedIntSource) {
+            // Consume the cache value
+            cachedIntSource = false;
+            // Return the lower 32 bits
+            return NumberFactory.extractLo(intSource);
+        }
+        // Fill the cache
+        cachedIntSource = true;
+        intSource = nextLong();
+        // Return the upper 32 bits
+        return NumberFactory.extractHi(intSource);
     }
 
     /** {@inheritDoc} */
@@ -56,7 +113,17 @@ public abstract class LongProvider
     /** {@inheritDoc} */
     @Override
     public boolean nextBoolean() {
-        return NumberFactory.makeBoolean(nextLong());
+        // Shift up. This will eventually overflow and become zero.
+        booleanBitMask <<= 1;
+        // The mask will either contain a single bit or none.
+        if (booleanBitMask == 0) {
+            // Set the least significant bit
+            booleanBitMask = 1;
+            // Get the next value
+            booleanSource = nextLong();
+        }
+        // Return if the bit is set
+        return (booleanSource & booleanBitMask) != 0;
     }
 
     /** {@inheritDoc} */

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/IntProviderTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/IntProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source32;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The tests the caching of calls to {@link IntProvider#nextInt()} are used as
+ * the source for {@link IntProvider#nextInt()} and
+ * {@link IntProvider#nextBoolean()}.
+ */
+public class IntProviderTest {
+    /**
+     * A simple class to flip the bits in a number as the source for
+     * {@link IntProvider#next()}.
+     */
+    static final class FlipIntProvider extends IntProvider {
+        /** The value. */
+        private int value;
+
+        /**
+         * @param value the value
+         */
+        public FlipIntProvider(int value) {
+            // Flip the bits so the first call to next() returns to the same state
+            this.value = ~value;
+        }
+
+        @Override
+        public int next() {
+            // Flip the bits
+            value = ~value;
+            return value;
+        }
+    }
+
+    /**
+     * This test ensures that the call to {@link IntProvider#nextBoolean()} returns
+     * each of the bits from a call to {@link IntProvider#nextInt()}.
+     *
+     * <p>The order should be from the least-significant bit.
+     */
+    @Test
+    public void testNextBoolean() {
+        for (int i = 0; i < Integer.SIZE; i++) {
+            // Set only a single bit in the source
+            final int value = 1 << i;
+            final IntProvider provider = new FlipIntProvider(value);
+            // Test the result for a single pass over the long
+            for (int j = 0; j < Integer.SIZE; j++) {
+                final boolean expected = (i == j);
+                Assert.assertEquals("Pass 1, bit " + j, expected, provider.nextBoolean());
+            }
+            // The second pass should use the opposite bits
+            for (int j = 0; j < Integer.SIZE; j++) {
+                final boolean expected = (i != j);
+                Assert.assertEquals("Pass 2, bit " + j, expected, provider.nextBoolean());
+            }
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/LongProviderTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/LongProviderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The tests the caching of calls to {@link LongProvider#nextLong()} are used as
+ * the source for {@link LongProvider#nextInt()} and
+ * {@link LongProvider#nextBoolean()}.
+ */
+public class LongProviderTest {
+    /**
+     * A simple class to return a fixed value as the source for
+     * {@link LongProvider#next()}.
+     */
+    static final class FixedLongProvider extends LongProvider {
+        /** The value. */
+        private long value;
+
+        /**
+         * @param value the value
+         */
+        public FixedLongProvider(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public long next() {
+            return value;
+        }
+    }
+
+    /**
+     * A simple class to flip the bits in a number as the source for
+     * {@link LongProvider#next()}.
+     */
+    static final class FlipLongProvider extends LongProvider {
+        /** The value. */
+        private long value;
+
+        /**
+         * @param value the value
+         */
+        public FlipLongProvider(long value) {
+            // Flip the bits so the first call to next() returns to the same state
+            this.value = ~value;
+        }
+
+        @Override
+        public long next() {
+            // Flip the bits
+            value = ~value;
+            return value;
+        }
+    }
+
+    /**
+     * This test ensures that the call to {@link LongProvider#nextInt()} returns the
+     * upper and then lower 32-bits from {@link LongProvider#nextLong()}.
+     */
+    @Test
+    public void testNextInt() {
+        final int MAX = 5;
+        for (int i = 0; i < MAX; i++) {
+            for (int j = 0; j < MAX; j++) {
+                // Pack into upper then lower bits
+                final long value = (((long) i) << 32) | (j & 0xffffffffL);
+                final LongProvider provider = new FixedLongProvider(value);
+                Assert.assertEquals("1st call not the upper 32-bits", i, provider.nextInt());
+                Assert.assertEquals("2nd call not the lower 32-bits", j, provider.nextInt());
+                Assert.assertEquals("3rd call not the upper 32-bits", i, provider.nextInt());
+                Assert.assertEquals("4th call not the lower 32-bits", j, provider.nextInt());
+            }
+        }
+    }
+
+    /**
+     * This test ensures that the call to {@link LongProvider#nextBoolean()} returns
+     * each of the bits from a call to {@link LongProvider#nextLong()}.
+     *
+     * <p>The order should be from the least-significant bit.
+     */
+    @Test
+    public void testNextBoolean() {
+        for (int i = 0; i < Long.SIZE; i++) {
+            // Set only a single bit in the source
+            final long value = 1L << i;
+            final LongProvider provider = new FlipLongProvider(value);
+            // Test the result for a single pass over the long
+            for (int j = 0; j < Long.SIZE; j++) {
+                final boolean expected = (i == j);
+                Assert.assertEquals("Pass 1, bit " + j, expected, provider.nextBoolean());
+            }
+            // The second pass should use the opposite bits
+            for (int j = 0; j < Long.SIZE; j++) {
+                final boolean expected = (i != j);
+                Assert.assertEquals("Pass 2, bit " + j, expected, provider.nextBoolean());
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- Fix for OpenJDK 8 now validating class-path attributes in Jar manifests. -->
+          <!-- See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912333#63 -->
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>**/*Test.java</include>
           </includes>


### PR DESCRIPTION
This PR contains the suggested changes to implement a cache to speed up the `nextInt` and `nextBoolean` methods in the core provider implementations.

These changes improve performance but the effect on the `nextInt` method of `LongProvider` is unknown. A repeat of the DieHarder and TestU01 test suites is currently in progress.
