### PR TITLE
fix: removed 1.8 annotation to ensure 1.7 compliance

### DIFF
--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/PoissonSamplerCachePerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/PoissonSamplerCachePerformance.java
@@ -268,7 +268,6 @@ public class PoissonSamplerCachePerformance {
     /**
      * A factory for creating Poisson sampler objects.
      */
-    @FunctionalInterface
     private interface PoissonSamplerFactory {
         /**
          * Creates a new Poisson sampler object.


### PR DESCRIPTION
Noticed this JDK 1.8 annotation when compiling on a machine with Open JDK 1.7 (it broke).

The pom.xml for commons-rng-examples uses 1.7 as the compliance level so this should be removed. The interface is not used with Lambda expressions anyway, i.e. the annotation should not be there.
