### PR TITLE
RNG-70: Add new XoShiRo generators

### DIFF
--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoRoShiRo64.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoRoShiRo64.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the Xor-Shift-Rotate family of 32-bit
+ * generators with 64-bits of state.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+abstract class AbstractXoRoShiRo64 extends IntProvider {
+    /** Size of the state vector. */
+    private static final int SEED_SIZE = 2;
+
+    // State is maintained using variables rather than an array for performance
+
+    /** State 0 of the generator. */
+    protected int state0;
+    /** State 1 of the generator. */
+    protected int state1;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    AbstractXoRoShiRo64(int[] seed) {
+        if (seed.length < SEED_SIZE) {
+            final int[] state = new int[SEED_SIZE];
+            fillState(state, seed);
+            setState(state);
+        } else {
+            setState(seed);
+        }
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    AbstractXoRoShiRo64(int seed0, int seed1) {
+        state0 = seed0;
+        state1 = seed1;
+    }
+
+    /**
+     * Creates a new instance using the upper and lower bits from the {@code long}
+     * to create a 2 element {@code int} seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed Initial seed.
+     */
+    AbstractXoRoShiRo64(long seed) {
+        state0 = NumberFactory.extractHi(seed);
+        state1 = NumberFactory.extractLo(seed);
+    }
+
+    /**
+     * Copies the state from the array into the generator state.
+     *
+     * @param state the new state
+     */
+    private void setState(int[] state) {
+        state0 = state[0];
+        state1 = state[1];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new int[] {state0, state1}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, SEED_SIZE * 4);
+
+        setState(NumberFactory.makeIntArray(c[0]));
+
+        super.setStateInternal(c[1]);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoRoShiRo64.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoRoShiRo64.java
@@ -44,8 +44,7 @@ abstract class AbstractXoRoShiRo64 extends IntProvider {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     AbstractXoRoShiRo64(int[] seed) {
         if (seed.length < SEED_SIZE) {
@@ -67,18 +66,6 @@ abstract class AbstractXoRoShiRo64 extends IntProvider {
     AbstractXoRoShiRo64(int seed0, int seed1) {
         state0 = seed0;
         state1 = seed1;
-    }
-
-    /**
-     * Creates a new instance using the upper and lower bits from the {@code long}
-     * to create a 2 element {@code int} seed.
-     * A seed containing all zeros will create a non-functional generator.
-     *
-     * @param seed Initial seed.
-     */
-    AbstractXoRoShiRo64(long seed) {
-        state0 = NumberFactory.extractHi(seed);
-        state1 = NumberFactory.extractLo(seed);
     }
 
     /**

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoShiRo128.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoShiRo128.java
@@ -48,8 +48,7 @@ abstract class AbstractXoShiRo128 extends IntProvider {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     AbstractXoShiRo128(int[] seed) {
         if (seed.length < SEED_SIZE) {

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoShiRo128.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/AbstractXoShiRo128.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the Xor-Shift-Rotate family of 32-bit
+ * generators with 128-bits of state.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+abstract class AbstractXoShiRo128 extends IntProvider {
+    /** Size of the state vector. */
+    private static final int SEED_SIZE = 4;
+
+    // State is maintained using variables rather than an array for performance
+
+    /** State 0 of the generator. */
+    protected int state0;
+    /** State 1 of the generator. */
+    protected int state1;
+    /** State 2 of the generator. */
+    protected int state2;
+    /** State 3 of the generator. */
+    protected int state3;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    AbstractXoShiRo128(int[] seed) {
+        if (seed.length < SEED_SIZE) {
+            final int[] state = new int[SEED_SIZE];
+            fillState(state, seed);
+            setState(state);
+        } else {
+            setState(seed);
+        }
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    AbstractXoShiRo128(int seed0, int seed1, int seed2, int seed3) {
+        state0 = seed0;
+        state1 = seed1;
+        state2 = seed2;
+        state3 = seed3;
+    }
+
+    /**
+     * Copies the state from the array into the generator state.
+     *
+     * @param state the new state
+     */
+    private void setState(int[] state) {
+        state0 = state[0];
+        state1 = state[1];
+        state2 = state[2];
+        state3 = state[3];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(
+                                        new int[] {state0, state1, state2, state3}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, SEED_SIZE * 4);
+
+        setState(NumberFactory.makeIntArray(c[0]));
+
+        super.setStateInternal(c[1]);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
@@ -21,7 +21,8 @@ package org.apache.commons.rng.core.source32;
  * A fast 32-bit generator suitable for {@code float} generation. This is slightly faster than the
  * all-purpose generator {@link XoRoShiRo64StarStar}.
  *
- * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64 bits.
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64
+ * bits.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoroshiro64star.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
@@ -35,8 +35,7 @@ public class XoRoShiRo64Star extends AbstractXoRoShiRo64 {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoRoShiRo64Star(int[] seed) {
         super(seed);
@@ -51,17 +50,6 @@ public class XoRoShiRo64Star extends AbstractXoRoShiRo64 {
      */
     public XoRoShiRo64Star(int seed0, int seed1) {
         super(seed0, seed1);
-    }
-
-    /**
-     * Creates a new instance using the upper and lower bits from the {@code long}
-     * to create a 2 element {@code int} seed.
-     * A seed containing all zeros will create a non-functional generator.
-     *
-     * @param seed Initial seed.
-     */
-    public XoRoShiRo64Star(long seed) {
-        super(seed);
     }
 
     /** {@inheritDoc} */

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64Star.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+/**
+ * A fast 32-bit generator suitable for {@code float} generation. This is slightly faster than the
+ * all-purpose generator {@link XoRoShiRo64StarStar}.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64 bits.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoroshiro64star.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoRoShiRo64Star extends AbstractXoRoShiRo64 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoRoShiRo64Star(int[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    public XoRoShiRo64Star(int seed0, int seed1) {
+        super(seed0, seed1);
+    }
+
+    /**
+     * Creates a new instance using the upper and lower bits from the {@code long}
+     * to create a 2 element {@code int} seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed Initial seed.
+     */
+    public XoRoShiRo64Star(long seed) {
+        super(seed);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int next() {
+        final int s0 = state0;
+        int s1 = state1;
+        final int result = s0 * 0x9E3779BB;
+
+        s1 ^= s0;
+        state0 = Integer.rotateLeft(s0, 26) ^ s1 ^ (s1 << 9); // a, b
+        state1 = Integer.rotateLeft(s1, 13); // c
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
@@ -21,7 +21,8 @@ package org.apache.commons.rng.core.source32;
  * A fast all-purpose 32-bit generator. For faster generation of {@code float} values try the
  * {@link XoRoShiRo64Star} generator.
  *
- * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64 bits.
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64
+ * bits.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoroshiro64starstar.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+/**
+ * A fast all-purpose 32-bit generator. For faster generation of {@code float} values try the
+ * {@link XoRoShiRo64Star} generator.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 64 bits.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoroshiro64starstar.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoRoShiRo64StarStar extends AbstractXoRoShiRo64 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoRoShiRo64StarStar(int[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    public XoRoShiRo64StarStar(int seed0, int seed1) {
+        super(seed0, seed1);
+    }
+
+    /**
+     * Creates a new instance using the upper and lower bits from the {@code long}
+     * to create a 2 element {@code int} seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed Initial seed.
+     */
+    public XoRoShiRo64StarStar(long seed) {
+        super(seed);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int next() {
+        final int s0 = state0;
+        int s1 = state1;
+        final int result = Integer.rotateLeft(s0 * 0x9E3779BB, 5) * 5;
+
+        s1 ^= s0;
+        state0 = Integer.rotateLeft(s0, 26) ^ s1 ^ (s1 << 9); // a, b
+        state1 = Integer.rotateLeft(s1, 13); // c
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStar.java
@@ -35,8 +35,7 @@ public class XoRoShiRo64StarStar extends AbstractXoRoShiRo64 {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoRoShiRo64StarStar(int[] seed) {
         super(seed);
@@ -51,17 +50,6 @@ public class XoRoShiRo64StarStar extends AbstractXoRoShiRo64 {
      */
     public XoRoShiRo64StarStar(int seed0, int seed1) {
         super(seed0, seed1);
-    }
-
-    /**
-     * Creates a new instance using the upper and lower bits from the {@code long}
-     * to create a 2 element {@code int} seed.
-     * A seed containing all zeros will create a non-functional generator.
-     *
-     * @param seed Initial seed.
-     */
-    public XoRoShiRo64StarStar(long seed) {
-        super(seed);
     }
 
     /** {@inheritDoc} */

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+/**
+ * A fast 32-bit generator suitable for {@code float} generation. This is slightly faster than the
+ * all-purpose generator {@link XoShiRo128StarStar}.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro128plus.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo128Plus extends AbstractXoShiRo128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo128Plus(int[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public XoShiRo128Plus(int seed0, int seed1, int seed2, int seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int next() {
+        final int result = state0 + state3;
+
+        final int t = state1 << 9;
+
+        state2 ^= state0;
+        state3 ^= state1;
+        state1 ^= state2;
+        state0 ^= state3;
+
+        state2 ^= t;
+
+        state3 = Integer.rotateLeft(state3, 11);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
@@ -21,7 +21,8 @@ package org.apache.commons.rng.core.source32;
  * A fast 32-bit generator suitable for {@code float} generation. This is slightly faster than the
  * all-purpose generator {@link XoShiRo128StarStar}.
  *
- * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits.
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128
+ * bits.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro128plus.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128Plus.java
@@ -35,8 +35,7 @@ public class XoShiRo128Plus extends AbstractXoShiRo128 {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo128Plus(int[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source32;
+
+/**
+ * A fast all-purpose 32-bit generator. For faster generation of {@code float} values try the
+ * {@link XoShiRo128Plus} generator.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro128starstar.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo128StarStar extends AbstractXoShiRo128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo128StarStar(int[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public XoShiRo128StarStar(int seed0, int seed1, int seed2, int seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int next() {
+        final int result = Integer.rotateLeft(state0 * 5, 7) * 9;
+
+        final int t = state1 << 9;
+
+        state2 ^= state0;
+        state3 ^= state1;
+        state1 ^= state2;
+        state0 ^= state3;
+
+        state2 ^= t;
+
+        state3 = Integer.rotateLeft(state3, 11);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
@@ -35,8 +35,7 @@ public class XoShiRo128StarStar extends AbstractXoShiRo128 {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo128StarStar(int[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/XoShiRo128StarStar.java
@@ -21,7 +21,8 @@ package org.apache.commons.rng.core.source32;
  * A fast all-purpose 32-bit generator. For faster generation of {@code float} values try the
  * {@link XoShiRo128Plus} generator.
  *
- * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits.
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128
+ * bits.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro128starstar.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo128.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo128.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the Xor-Shift-Rotate family of 64-bit
+ * generators with 128-bits of state.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+abstract class AbstractXoRoShiRo128 extends LongProvider {
+    /** Size of the state vector. */
+    private static final int SEED_SIZE = 2;
+
+    // State is maintained using variables rather than an array for performance
+
+    /** State 0 of the generator. */
+    protected long state0;
+    /** State 1 of the generator. */
+    protected long state1;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    AbstractXoRoShiRo128(long[] seed) {
+        if (seed.length < SEED_SIZE) {
+            final long[] state = new long[SEED_SIZE];
+            fillState(state, seed);
+            setState(state);
+        } else {
+            setState(seed);
+        }
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    AbstractXoRoShiRo128(long seed0, long seed1) {
+        state0 = seed0;
+        state1 = seed1;
+    }
+
+    /**
+     * Copies the state from the array into the generator state.
+     *
+     * @param state the new state
+     */
+    private void setState(long[] state) {
+        state0 = state[0];
+        state1 = state[1];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {state0, state1}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, SEED_SIZE * 8);
+
+        setState(NumberFactory.makeLongArray(c[0]));
+
+        super.setStateInternal(c[1]);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo128.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo128.java
@@ -44,8 +44,7 @@ abstract class AbstractXoRoShiRo128 extends LongProvider {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     AbstractXoRoShiRo128(long[] seed) {
         if (seed.length < SEED_SIZE) {

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo256.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo256.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the Xor-Shift-Rotate family of 64-bit
+ * generators with 256-bits of state.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+abstract class AbstractXoShiRo256 extends LongProvider {
+    /** Size of the state vector. */
+    private static final int SEED_SIZE = 4;
+
+    // State is maintained using variables rather than an array for performance
+
+    /** State 0 of the generator. */
+    protected long state0;
+    /** State 1 of the generator. */
+    protected long state1;
+    /** State 2 of the generator. */
+    protected long state2;
+    /** State 3 of the generator. */
+    protected long state3;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    AbstractXoShiRo256(long[] seed) {
+        if (seed.length < SEED_SIZE) {
+            final long[] state = new long[SEED_SIZE];
+            fillState(state, seed);
+            setState(state);
+        } else {
+            setState(seed);
+        }
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    AbstractXoShiRo256(long seed0, long seed1, long seed2, long seed3) {
+        state0 = seed0;
+        state1 = seed1;
+        state2 = seed2;
+        state3 = seed3;
+    }
+
+    /**
+     * Copies the state from the array into the generator state.
+     *
+     * @param state the new state
+     */
+    private void setState(long[] state) {
+        state0 = state[0];
+        state1 = state[1];
+        state2 = state[2];
+        state3 = state[3];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(
+                                        new long[] {state0, state1, state2, state3}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, SEED_SIZE * 8);
+
+        setState(NumberFactory.makeLongArray(c[0]));
+
+        super.setStateInternal(c[1]);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo256.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo256.java
@@ -48,8 +48,7 @@ abstract class AbstractXoShiRo256 extends LongProvider {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     AbstractXoShiRo256(long[] seed) {
         if (seed.length < SEED_SIZE) {

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo512.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo512.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the Xor-Shift-Rotate family of 64-bit
+ * generators with 512-bits of state.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+abstract class AbstractXoShiRo512 extends LongProvider {
+    /** Size of the state vector. */
+    private static final int SEED_SIZE = 8;
+
+    // State is maintained using variables rather than an array for performance
+
+    /** State 0 of the generator. */
+    protected long state0;
+    /** State 1 of the generator. */
+    protected long state1;
+    /** State 2 of the generator. */
+    protected long state2;
+    /** State 3 of the generator. */
+    protected long state3;
+    /** State 4 of the generator. */
+    protected long state4;
+    /** State 5 of the generator. */
+    protected long state5;
+    /** State 6 of the generator. */
+    protected long state6;
+    /** State 7 of the generator. */
+    protected long state7;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 8, only the first 8 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    AbstractXoShiRo512(long[] seed) {
+        if (seed.length < SEED_SIZE) {
+            final long[] state = new long[SEED_SIZE];
+            fillState(state, seed);
+            setState(state);
+        } else {
+            setState(seed);
+        }
+    }
+
+    /**
+     * Creates a new instance using an 8 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     * @param seed6 Initial seed element 6.
+     * @param seed7 Initial seed element 7.
+     */
+    AbstractXoShiRo512(long seed0, long seed1, long seed2, long seed3,
+                              long seed4, long seed5, long seed6, long seed7) {
+        state0 = seed0;
+        state1 = seed1;
+        state2 = seed2;
+        state3 = seed3;
+        state4 = seed4;
+        state5 = seed5;
+        state6 = seed6;
+        state7 = seed7;
+    }
+
+    /**
+     * Copies the state from the array into the generator state.
+     *
+     * @param state the new state
+     */
+    private void setState(long[] state) {
+        state0 = state[0];
+        state1 = state[1];
+        state2 = state[2];
+        state3 = state[3];
+        state4 = state[4];
+        state5 = state[5];
+        state6 = state[6];
+        state7 = state[7];
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(
+                                        new long[] {state0, state1, state2, state3,
+                                                    state4, state5, state6, state7}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, SEED_SIZE * 8);
+
+        setState(NumberFactory.makeLongArray(c[0]));
+
+        super.setStateInternal(c[1]);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo512.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoShiRo512.java
@@ -56,8 +56,7 @@ abstract class AbstractXoShiRo512 extends LongProvider {
      * @param seed Initial seed.
      * If the length is larger than 8, only the first 8 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     AbstractXoShiRo512(long[] seed) {
         if (seed.length < SEED_SIZE) {

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast 64-bit generator suitable for {@code double} generation. This is slightly faster than the
+ * all-purpose generator {@link XoRoShiRo128StarStar}.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits
+ * and the period is 2<sup>128</sup>-1. Speed is expected to be similar to
+ * {@link XoShiRo256Plus}.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoroshiro128plus.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoRoShiRo128Plus extends AbstractXoRoShiRo128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoRoShiRo128Plus(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    public XoRoShiRo128Plus(long seed0, long seed1) {
+        super(seed0, seed1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long s0 = state0;
+        long s1 = state1;
+        final long result = s0 + s1;
+
+        s1 ^= s0;
+        state0 = Long.rotateLeft(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+        state1 = Long.rotateLeft(s1, 37); // c
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
@@ -37,8 +37,7 @@ public class XoRoShiRo128Plus extends AbstractXoRoShiRo128 {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoRoShiRo128Plus(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128Plus.java
@@ -23,7 +23,7 @@ package org.apache.commons.rng.core.source64;
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits
  * and the period is 2<sup>128</sup>-1. Speed is expected to be similar to
- * {@link XoShiRo256Plus}.
+ * {@link XoShiRo256Plus}.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoroshiro128plus.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
@@ -22,7 +22,7 @@ package org.apache.commons.rng.core.source64;
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits
  * and the period is 2<sup>128</sup>-1. Speed is expected to be similar to
- * {@link XoShiRo256StarStar}.
+ * {@link XoShiRo256StarStar}.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoroshiro128statstar.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast all-purpose 64-bit generator.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 128 bits
+ * and the period is 2<sup>128</sup>-1. Speed is expected to be similar to
+ * {@link XoShiRo256StarStar}.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoroshiro128statstar.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoRoShiRo128StarStar extends AbstractXoRoShiRo128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 2, only the first 2 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoRoShiRo128StarStar(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 2 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     */
+    public XoRoShiRo128StarStar(long seed0, long seed1) {
+        super(seed0, seed1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long s0 = state0;
+        long s1 = state1;
+        final long result = Long.rotateLeft(s0 * 5, 7) * 9;
+
+        s1 ^= s0;
+        state0 = Long.rotateLeft(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+        state1 = Long.rotateLeft(s1, 37); // c
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStar.java
@@ -36,8 +36,7 @@ public class XoRoShiRo128StarStar extends AbstractXoRoShiRo128 {
      * @param seed Initial seed.
      * If the length is larger than 2, only the first 2 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoRoShiRo128StarStar(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
@@ -22,7 +22,7 @@ package org.apache.commons.rng.core.source64;
  * all-purpose generator {@link XoShiRo256StarStar}.
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 256 bits
- * and the period is 2<sup>256</sup>-1.
+ * and the period is 2<sup>256</sup>-1.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro256plus.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
@@ -36,8 +36,7 @@ public class XoShiRo256Plus extends AbstractXoShiRo256 {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo256Plus(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256Plus.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast 64-bit generator suitable for {@code double} generation. This is slightly faster than the
+ * all-purpose generator {@link XoShiRo256StarStar}.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 256 bits
+ * and the period is 2<sup>256</sup>-1.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro256plus.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo256Plus extends AbstractXoShiRo256 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo256Plus(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public XoShiRo256Plus(long seed0, long seed1, long seed2, long seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long result = state0 + state3;
+
+        final long t = state1 << 17;
+
+        state2 ^= state0;
+        state3 ^= state1;
+        state1 ^= state2;
+        state0 ^= state3;
+
+        state2 ^= t;
+
+        state3 = Long.rotateLeft(state3, 45);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast all-purpose 64-bit generator.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 256 bits
+ * and the period is 2<sup>256</sup>-1.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro256starstar.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo256StarStar extends AbstractXoShiRo256 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo256StarStar(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public XoShiRo256StarStar(long seed0, long seed1, long seed2, long seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long result = Long.rotateLeft(state1 * 5, 7) * 9;
+
+        final long t = state1 << 17;
+
+        state2 ^= state0;
+        state3 ^= state1;
+        state1 ^= state2;
+        state0 ^= state3;
+
+        state2 ^= t;
+
+        state3 = Long.rotateLeft(state3, 45);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
@@ -21,7 +21,7 @@ package org.apache.commons.rng.core.source64;
  * A fast all-purpose 64-bit generator.
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 256 bits
- * and the period is 2<sup>256</sup>-1.
+ * and the period is 2<sup>256</sup>-1.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro256starstar.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo256StarStar.java
@@ -35,8 +35,7 @@ public class XoShiRo256StarStar extends AbstractXoShiRo256 {
      * @param seed Initial seed.
      * If the length is larger than 4, only the first 4 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo256StarStar(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
@@ -36,8 +36,7 @@ public class XoShiRo512Plus extends AbstractXoShiRo512 {
      * @param seed Initial seed.
      * If the length is larger than 8, only the first 8 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo512Plus(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast 64-bit generator suitable for {@code double} generation. This is slightly faster than the
+ * all-purpose generator {@link XoShiRo512StarStar}.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 512 bits
+ * and the period is 2<sup>512</sup>-1. Speed is expected to be slower than {@link XoShiRo256Plus}.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro512plus.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo512Plus extends AbstractXoShiRo512 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 8, only the first 8 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo512Plus(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using an 8 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     * @param seed6 Initial seed element 6.
+     * @param seed7 Initial seed element 7.
+     */
+    public XoShiRo512Plus(long seed0, long seed1, long seed2, long seed3,
+                          long seed4, long seed5, long seed6, long seed7) {
+        super(seed0, seed1, seed2, seed3, seed4, seed5, seed6, seed7);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long result = state0 + state2;
+
+        final long t = state1 << 11;
+
+        state2 ^= state0;
+        state5 ^= state1;
+        state1 ^= state2;
+        state7 ^= state3;
+        state3 ^= state4;
+        state4 ^= state5;
+        state0 ^= state6;
+        state6 ^= state7;
+
+        state6 ^= t;
+
+        state7 = Long.rotateLeft(state7, 21);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512Plus.java
@@ -22,7 +22,8 @@ package org.apache.commons.rng.core.source64;
  * all-purpose generator {@link XoShiRo512StarStar}.
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 512 bits
- * and the period is 2<sup>512</sup>-1. Speed is expected to be slower than {@link XoShiRo256Plus}.
+ * and the period is 2<sup>512</sup>-1. Speed is expected to be slower than
+ * {@link XoShiRo256Plus}.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro512plus.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
@@ -36,8 +36,7 @@ public class XoShiRo512StarStar extends AbstractXoShiRo512 {
      * @param seed Initial seed.
      * If the length is larger than 8, only the first 8 elements will
      * be used; if smaller, the remaining elements will be automatically
-     * set.
-     * A seed containing all zeros will create a non-functional generator.
+     * set. A seed containing all zeros will create a non-functional generator.
      */
     public XoShiRo512StarStar(long[] seed) {
         super(seed);

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
@@ -22,7 +22,7 @@ package org.apache.commons.rng.core.source64;
  *
  * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 512 bits
  * and the period is 2<sup>512</sup>-1. Speed is expected to be slower than
- * {@link XoShiRo256StarStar}.
+ * {@link XoShiRo256StarStar}.</p>
  *
  * @see <a href="http://xoshiro.di.unimi.it/xoshiro512starstar.c">Original source code</a>
  * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/XoShiRo512StarStar.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A fast all-purpose generator.
+ *
+ * <p>This is a member of the Xor-Shift-Rotate family of generators. Memory footprint is 512 bits
+ * and the period is 2<sup>512</sup>-1. Speed is expected to be slower than
+ * {@link XoShiRo256StarStar}.
+ *
+ * @see <a href="http://xoshiro.di.unimi.it/xoshiro512starstar.c">Original source code</a>
+ * @see <a href="http://xoshiro.di.unimi.it/">xorshiro / xoroshiro generators</a>
+ *
+ * @since 1.3
+ */
+public class XoShiRo512StarStar extends AbstractXoShiRo512 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 8, only the first 8 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set.
+     * A seed containing all zeros will create a non-functional generator.
+     */
+    public XoShiRo512StarStar(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using an 8 element seed.
+     * A seed containing all zeros will create a non-functional generator.
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     * @param seed6 Initial seed element 6.
+     * @param seed7 Initial seed element 7.
+     */
+    public XoShiRo512StarStar(long seed0, long seed1, long seed2, long seed3,
+                              long seed4, long seed5, long seed6, long seed7) {
+        super(seed0, seed1, seed2, seed3, seed4, seed5, seed6, seed7);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        final long result = Long.rotateLeft(state1 * 5, 7) * 9;
+
+        final long t = state1 << 11;
+
+        state2 ^= state0;
+        state5 ^= state1;
+        state1 ^= state2;
+        state7 ^= state3;
+        state3 ^= state4;
+        state4 ^= state5;
+        state0 ^= state6;
+        state6 ^= state7;
+
+        state6 ^= t;
+
+        state7 = Long.rotateLeft(state7, 21);
+
+        return result;
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/ProvidersList.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/ProvidersList.java
@@ -23,6 +23,10 @@ import java.security.SecureRandom;
 
 import org.apache.commons.rng.core.source32.JDKRandom;
 import org.apache.commons.rng.core.source32.Well512a;
+import org.apache.commons.rng.core.source32.XoRoShiRo64Star;
+import org.apache.commons.rng.core.source32.XoRoShiRo64StarStar;
+import org.apache.commons.rng.core.source32.XoShiRo128Plus;
+import org.apache.commons.rng.core.source32.XoShiRo128StarStar;
 import org.apache.commons.rng.core.source32.Well1024a;
 import org.apache.commons.rng.core.source32.Well19937a;
 import org.apache.commons.rng.core.source32.Well19937c;
@@ -36,6 +40,12 @@ import org.apache.commons.rng.core.source64.SplitMix64;
 import org.apache.commons.rng.core.source64.XorShift1024Star;
 import org.apache.commons.rng.core.source64.XorShift1024StarPhi;
 import org.apache.commons.rng.core.source64.TwoCmres;
+import org.apache.commons.rng.core.source64.XoRoShiRo128Plus;
+import org.apache.commons.rng.core.source64.XoRoShiRo128StarStar;
+import org.apache.commons.rng.core.source64.XoShiRo256Plus;
+import org.apache.commons.rng.core.source64.XoShiRo256StarStar;
+import org.apache.commons.rng.core.source64.XoShiRo512Plus;
+import org.apache.commons.rng.core.source64.XoShiRo512StarStar;
 import org.apache.commons.rng.core.source64.MersenneTwister64;
 import org.apache.commons.rng.RestorableUniformRandomProvider;
 
@@ -76,6 +86,10 @@ public class ProvidersList {
             add(LIST32, new ISAACRandom(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
             add(LIST32, new MultiplyWithCarry256(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
             add(LIST32, new KISSRandom(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
+            add(LIST32, new XoRoShiRo64Star(new int[] { g.nextInt(), g.nextInt() }));
+            add(LIST32, new XoRoShiRo64StarStar(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
+            add(LIST32, new XoShiRo128Plus(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
+            add(LIST32, new XoShiRo128StarStar(new int[] { g.nextInt(), g.nextInt(), g.nextInt() }));
             // ... add more here.
 
             // "long"-based RNGs.
@@ -85,6 +99,12 @@ public class ProvidersList {
             add(LIST64, new TwoCmres(g.nextInt()));
             add(LIST64, new TwoCmres(g.nextInt(), 5, 8));
             add(LIST64, new MersenneTwister64(new long[] { g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoRoShiRo128Plus(new long[] { g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoRoShiRo128StarStar(new long[] { g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoShiRo256Plus(new long[] { g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoShiRo256StarStar(new long[] { g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoShiRo512Plus(new long[] { g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong() }));
+            add(LIST64, new XoShiRo512StarStar(new long[] { g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong() }));
             // ... add more here.
 
             // Do not modify the remaining statements.

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStarTest.java
@@ -75,16 +75,4 @@ public class XoRoShiRo64StarStarTest {
             Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
         }
     }
-
-    @Test
-    public void testLongElementConstructor() {
-        final int[] seed = {
-            0x012de1ba, 0xa5a818b8,
-        };
-        final XoRoShiRo64StarStar rng1 = new XoRoShiRo64StarStar(seed);
-        final XoRoShiRo64StarStar rng2 = new XoRoShiRo64StarStar(NumberFactory.makeLong(seed[0], seed[1]));
-        for (int i = seed.length * 2; i-- != 0; ) {
-            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
-        }
-    }
 }

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarStarTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.apache.commons.rng.core.util.NumberFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoRoShiRo64StarStarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoroshiro64starstar.c
+         */
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+
+        final int[] expectedSequence = {
+            0x7ac00b42, 0x1f638399, 0x09e4aea4, 0x05cbbd64,
+            0x1c967b7b, 0x1cf852fd, 0xc666f4e8, 0xeea9f1ae,
+            0xca0fa6bc, 0xa65d0905, 0xa69afc95, 0x34965e62,
+            0xdd4f04a9, 0xff1c9342, 0x638ff769, 0x03419ca0,
+            0xb46e6dfd, 0xf7555b22, 0x8cab4e68, 0x5a44b6ee,
+            0x4e5e1eed, 0xd03c5963, 0x782d05ed, 0x41bda3e3,
+            0xd1d65005, 0x88f43a8a, 0xfffe02ea, 0xb326624a,
+            0x1ec0034c, 0xb903d8df, 0x78454bd7, 0xaec630f8,
+            0x2a0c9a3a, 0xc2594988, 0xe71e767e, 0x4e0e1ddc,
+            0xae945004, 0xf178c293, 0xa04081d6, 0xdd9c062f,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoRoShiRo64StarStar(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 2;
+        final XoRoShiRo64StarStar rng = new XoRoShiRo64StarStar(new int[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0, rng.nextInt());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoRoShiRo64StarStar(new int[] { 0x012de1ba });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+        final XoRoShiRo64StarStar rng1 = new XoRoShiRo64StarStar(seed);
+        final XoRoShiRo64StarStar rng2 = new XoRoShiRo64StarStar(seed[0], seed[1]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+
+    @Test
+    public void testLongElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+        final XoRoShiRo64StarStar rng1 = new XoRoShiRo64StarStar(seed);
+        final XoRoShiRo64StarStar rng2 = new XoRoShiRo64StarStar(NumberFactory.makeLong(seed[0], seed[1]));
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarTest.java
@@ -75,16 +75,4 @@ public class XoRoShiRo64StarTest {
             Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
         }
     }
-
-    @Test
-    public void testLongElementConstructor() {
-        final int[] seed = {
-            0x012de1ba, 0xa5a818b8,
-        };
-        final XoRoShiRo64Star rng1 = new XoRoShiRo64Star(seed);
-        final XoRoShiRo64Star rng2 = new XoRoShiRo64Star(NumberFactory.makeLong(seed[0], seed[1]));
-        for (int i = seed.length * 2; i-- != 0; ) {
-            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
-        }
-    }
 }

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoRoShiRo64StarTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.apache.commons.rng.core.util.NumberFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoRoShiRo64StarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoroshiro64star.c
+         */
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+
+        final int[] expectedSequence = {
+            0xd72accde, 0x29cbd26c, 0xa00fd44a, 0xa4d612c8,
+            0xf9c7572b, 0xce94c084, 0x47a3d7ee, 0xb64aa982,
+            0x67a9b2a4, 0x0c3d61a8, 0x8f70f7fa, 0xd1edbd63,
+            0xac954b3a, 0xd7fe941e, 0xaa38e658, 0x019ecf61,
+            0xcded7d7c, 0xd6588891, 0x4414454a, 0xb3c3a124,
+            0x4a16fcfe, 0x3fb393c2, 0x4d8d14d6, 0x3a02c906,
+            0x0c82f080, 0x174186c4, 0x1199966b, 0x12b83d6a,
+            0xe697999e, 0x9df4d2f4, 0x5a5a0879, 0xc44ad6b4,
+            0x96a9adc3, 0x4603c20f, 0x3171ca57, 0x66e349c9,
+            0xa77dba19, 0xbe4f279d, 0xf5cd3402, 0x1962933d,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoRoShiRo64Star(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 2;
+        final XoRoShiRo64Star rng = new XoRoShiRo64Star(new int[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0, rng.nextInt());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoRoShiRo64Star(new int[] { 0x012de1ba });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+        final XoRoShiRo64Star rng1 = new XoRoShiRo64Star(seed);
+        final XoRoShiRo64Star rng2 = new XoRoShiRo64Star(seed[0], seed[1]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+
+    @Test
+    public void testLongElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8,
+        };
+        final XoRoShiRo64Star rng1 = new XoRoShiRo64Star(seed);
+        final XoRoShiRo64Star rng2 = new XoRoShiRo64Star(NumberFactory.makeLong(seed[0], seed[1]));
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoShiRo128PlusTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoShiRo128PlusTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo128PlusTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro128plus.c
+         */
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8, 0xb124ea2b, 0x18e03749,
+        };
+
+        final int[] expectedSequence = {
+            0x1a0e1903, 0xfde55c35, 0xddb16b2e, 0xab949ac5,
+            0xb5519fea, 0xc6a97473, 0x1f0403d9, 0x1bb46995,
+            0x79c99a12, 0xe447ebce, 0xa8c31d78, 0x54d8bbe3,
+            0x4984a039, 0xb411e932, 0x9c1f2c5e, 0x5f53c469,
+            0x7f333552, 0xb368c7a1, 0xa57b8e66, 0xb29a9444,
+            0x5c389bfa, 0x8e7d3758, 0xfe17a1bb, 0xcd0aad57,
+            0xde83c4bb, 0x1402339d, 0xb557a080, 0x4f828bc9,
+            0xde14892d, 0xbba8eaed, 0xab62ebbb, 0x4ad959a4,
+            0x3c6ee9c7, 0x4f6a6fd3, 0xd5785eed, 0x1a0227d1,
+            0x81314acb, 0xfabdfb97, 0x7e1b7e90, 0x57544e23,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo128Plus(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 4;
+        final XoShiRo128Plus rng = new XoShiRo128Plus(new int[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0, rng.nextInt());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo128Plus(new int[] { 0x012de1ba });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8, 0xb124ea2b, 0x18e03749,
+        };
+        final XoShiRo128Plus rng1 = new XoShiRo128Plus(seed);
+        final XoShiRo128Plus rng2 = new XoShiRo128Plus(seed[0], seed[1], seed[2], seed[3]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoShiRo128StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/XoShiRo128StarStarTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source32;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo128StarStarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro128starstar.c
+         */
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8, 0xb124ea2b, 0x18e03749,
+        };
+
+        final int[] expectedSequence = {
+            0x8856d912, 0xf2a19a86, 0x7693f66d, 0x23516f86,
+            0x4895054e, 0xf4503fe6, 0x40e04672, 0x99244e34,
+            0xb971815c, 0x3008b82c, 0x0ee73b58, 0x88aad2c6,
+            0x7923f2e9, 0xfde55485, 0x7aed95f5, 0xeb8abb59,
+            0xca78183a, 0x80ecdd68, 0xfd404b06, 0x248b9c9e,
+            0xa2c69c6f, 0x1723b375, 0x879f37b0, 0xe98fd208,
+            0x75de84a9, 0x717d6df8, 0x92cd7bc7, 0x46380167,
+            0x7f08600b, 0x58566f2b, 0x7f781475, 0xe34ec04d,
+            0x6d5ef889, 0xb76ff6d8, 0x501f5df6, 0x4cf70ccb,
+            0xd7375b26, 0x457ea1ab, 0x7439e565, 0x355855af,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo128StarStar(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 4;
+        final XoShiRo128StarStar rng = new XoShiRo128StarStar(new int[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0, rng.nextInt());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo128StarStar(new int[] { 0x012de1ba });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final int[] seed = {
+            0x012de1ba, 0xa5a818b8, 0xb124ea2b, 0x18e03749,
+        };
+        final XoShiRo128StarStar rng1 = new XoShiRo128StarStar(seed);
+        final XoShiRo128StarStar rng2 = new XoShiRo128StarStar(seed[0], seed[1], seed[2], seed[3]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextInt(), rng2.nextInt());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoRoShiRo128PlusTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoRoShiRo128PlusTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoRoShiRo128PlusTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoroshiro128plus.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L,
+        };
+
+        final long[] expectedSequence = {
+            0xa6d5fa73b796e607L, 0xd419031a381fea2eL, 0x28938b88b4972f52L, 0x032793a0d51c1a27L,
+            0x50001cd69cc5b006L, 0x44bbf571167cb7f0L, 0x172f6a2f093b2befL, 0xe642c831f1e4f7bfL,
+            0xcec4e4b5d448032aL, 0xc0164992807cbd59L, 0xb96ff06c68515410L, 0x5288e0312a0aae72L,
+            0x79a891c387d3be2eL, 0x6c52f6f710db553bL, 0x2ce6f6b1946862b3L, 0x87eb1e1b24b47f11L,
+            0x9f7c3511c5f23bcfL, 0x3254897533dcd1abL, 0x89d56ad217fbd1adL, 0x70f6b269f815f6e6L,
+            0xe8ee60efadfdb8c4L, 0x09286db69fdd232bL, 0xf440882651fc19e8L, 0x6356fea018cc26cdL,
+            0xf692282b43fcb0c2L, 0xef3f084929119babL, 0x355efbf5bedeb114L, 0x6cf5089c2acc96ddL,
+            0x819c19e480f0bfd1L, 0x414d12ff4082e261L, 0xc9a33a52545dd374L, 0x4675247e6fe89b3cL,
+            0x069f2e55cea155baL, 0x1e8d1dcf349746b8L, 0xdf32e487bdd74523L, 0xa544710cae2ad7cdL,
+            0xf5ac505e74fe049dL, 0xf039e289da4cdf7eL, 0x0a6fbebe9122529cL, 0x880c51e0915031a3L,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoRoShiRo128Plus(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 2;
+        final XoRoShiRo128Plus rng = new XoRoShiRo128Plus(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoRoShiRo128Plus(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L,
+        };
+        final XoRoShiRo128Plus rng1 = new XoRoShiRo128Plus(seed);
+        final XoRoShiRo128Plus rng2 = new XoRoShiRo128Plus(seed[0], seed[1]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoRoShiRo128StarStarTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoRoShiRo128StarStarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoroshiro128starstar.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L,
+        };
+
+        final long[] expectedSequence = {
+            0x8856e974cbb6da12L, 0xd1704f3601beb952L, 0x368a027941bc61e7L, 0x882b24dcfa3ada58L,
+            0xfa8dafb3363143fbL, 0x2eb9417a5dcf7654L, 0xed8722e0a73e975bL, 0x435fff57a631d485L,
+            0x954f1ad2377632b8L, 0x9aa2f4dcba28ab71L, 0xaca10369f96ac911L, 0x968088e7277d0369L,
+            0x662e442ae32c42b4L, 0xe1cd476f71dd058eL, 0xb462a3c2bbb650f8L, 0x74749215e8c07d08L,
+            0x1629f3cb1a671dbbL, 0x3636dcc702eadf55L, 0x97ae682e61cb3f57L, 0xfdf8fc5ea9541f3bL,
+            0x2dfdb23d99c34accL, 0x68bef4f41a8f4113L, 0x5cd03dc43f7af892L, 0xdc2184abe0565da1L,
+            0x1dfaece40d9f96d0L, 0x7d7b19285818ab71L, 0xedea7fd3a0e47018L, 0x23542ee7ed294823L,
+            0x1719f2b97bfc26c4L, 0x2c7b7e288b399818L, 0x49fa00786a1f5ad9L, 0xd97cdfbe81700be2L,
+            0x557480baa4d9e5b2L, 0x840a0403c0e85d92L, 0xb4d5c6b2dc19dab2L, 0xdf1b570e3bf1cf1bL,
+            0x26d1ac9455ccc75fL, 0xdcc0e5fe06d1e231L, 0x5164b7650568120eL, 0x5fa82f6598483607L,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoRoShiRo128StarStar(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 2;
+        final XoRoShiRo128StarStar rng = new XoRoShiRo128StarStar(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoRoShiRo128StarStar(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L,
+        };
+        final XoRoShiRo128StarStar rng1 = new XoRoShiRo128StarStar(seed);
+        final XoRoShiRo128StarStar rng2 = new XoRoShiRo128StarStar(seed[0], seed[1]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo256PlusTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo256PlusTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo256PlusTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro256plus.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+        };
+
+        final long[] expectedSequence = {
+            0x1a0e1903ef150886L, 0x08b605f47abc5d75L, 0xd82176096ac9be31L, 0x8fbf2af9b4fa5405L,
+            0x9ab074b448171964L, 0xfd68cc83ab4360aaL, 0xf431f7c0c8dc6f2bL, 0xc04430be08212638L,
+            0xc1ad670648f1da03L, 0x3eb70d38796ba24aL, 0x0e474d0598251ed2L, 0xf9b6b3b56482566bL,
+            0x3d11e529ae07a7c8L, 0x3b195f84f4db17e7L, 0x09d62e817b8223e2L, 0x89dc4db9cd625509L,
+            0x52e04793fe977846L, 0xc052428d6d7d17cdL, 0x6fd6f8da306b10efL, 0x64a7996ba5cc80aaL,
+            0x03abf59b95a1ef20L, 0xc5a82fc3cfb50234L, 0x0d401229eabb2d39L, 0xb537b249f70bd18aL,
+            0x1af1b703753fcf4dL, 0xb84648c1945d9ccbL, 0x1d321bea673e1f66L, 0x93d4445b268f305fL,
+            0xc046cfa36d89a312L, 0x8cc2d55bbf778790L, 0x1d668b0a3d329cc7L, 0x81b6d533dfcf82deL,
+            0x9ca1c49a18537b16L, 0x68e55c4054e0cb72L, 0x06ed1956cb69afc6L, 0x4871e696449da910L,
+            0xcfbd7a145066d46eL, 0x10131cb15004b62dL, 0x489c91a322bca3b6L, 0x8ec95fa9bef73e66L,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo256Plus(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 4;
+        final XoShiRo256Plus rng = new XoShiRo256Plus(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo256Plus(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+        };
+        final XoShiRo256Plus rng1 = new XoShiRo256Plus(seed);
+        final XoShiRo256Plus rng2 = new XoShiRo256Plus(seed[0], seed[1], seed[2], seed[3]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo256StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo256StarStarTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo256StarStarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro256starstar.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+        };
+
+        final long[] expectedSequence = {
+            0x462c422df780c48eL, 0xa82f1f6031c183e6L, 0x8a113820e8d2ca8dL, 0x1ac7023a26534958L,
+            0xac8e41d0101e109cL, 0x46e34bc13edd63c4L, 0x3a26776adcd665c3L, 0x9ac6c9bea8fc518cL,
+            0x1cef0aa07cc738c4L, 0x5136a5f070244b1dL, 0x12e2e12edee691ffL, 0x28942b20799b71b4L,
+            0xbe2d5c4267af2469L, 0x9dbec53728b2b9b7L, 0x893cf86611b14a96L, 0x712c226c79f066d6L,
+            0x1a8a11ef81d2ac60L, 0x28171739ef8f2f46L, 0x073baa93525f8b1dL, 0xa73c7f3cb93df678L,
+            0xae5633ab977a3531L, 0x25314041ba2d047eL, 0x31e6819dea142672L, 0x9479fa694f4c2965L,
+            0xde5b771a968472b7L, 0xf0501965d9eeb4a3L, 0xef25a2a8ec90b911L, 0x1f58f71a75392659L,
+            0x32d9547188781f3cL, 0x2d13b036ccf65bc0L, 0x289f9cc038dd952fL, 0x6ae2d5231e50824aL,
+            0x75651acfb42ab170L, 0x7369aeb4f10056cfL, 0x0297ed632a97cf75L, 0x19f534c778015b72L,
+            0x5d1d111c5ff182a8L, 0x861cdfe8e8014b96L, 0x07c6071e08112c83L, 0x15601582dcf4e4feL,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo256StarStar(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 4;
+        final XoShiRo256StarStar rng = new XoShiRo256StarStar(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo256StarStar(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+        };
+        final XoShiRo256StarStar rng1 = new XoShiRo256StarStar(seed);
+        final XoShiRo256StarStar rng2 = new XoShiRo256StarStar(seed[0], seed[1], seed[2], seed[3]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo512PlusTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo512PlusTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo512PlusTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro512plus.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+            0x2af8df668d68ad55L, 0x76e56f59daa06243L, 0xf58c016f0f01e30fL, 0x8eeafa41683dbbf4L,
+        };
+
+        final long[] expectedSequence = {
+            0xb252cbe62b5b8a97L, 0xa4aaec677f60aaa2L, 0x1c8bd694b50fd00eL, 0x02753e0294233973L,
+            0xbfec0be86d152e2dL, 0x5b9cd7265f320e98L, 0xf8ec45eccc703724L, 0x83fcbefa0359b3c1L,
+            0xbd27fcdb7e79265dL, 0x88934227d8bf3cf0L, 0x99e1e79384f40371L, 0xe7e7fd0af2014912L,
+            0xebdd19cbcd35745dL, 0x218994e1747243eeL, 0x80628718e5d310daL, 0x88ba1395debd989cL,
+            0x72e025c0928c6f55L, 0x51400eaa050bbb0aL, 0x72542ad3e7fe29e9L, 0x3a3355b9dcb9c8b0L,
+            0x2f6618f3df6126f4L, 0x34307608d886d40fL, 0x34f5a22e98fe3375L, 0x558f6560d08b9ec3L,
+            0xae78928bcb041d6cL, 0xe7afe32a7caf4587L, 0x22dcfb5ca129d4bdL, 0x7c5a41864a6f2cf6L,
+            0xbe1186add0fe46a7L, 0xd019fabc10dc96a5L, 0xafa642ef6837d342L, 0xdc4924811f62cf03L,
+            0xdeb486ccebccf747L, 0xd827b16c9189f637L, 0xf1aab3c3c690a71dL, 0x6551214a7f04a2a5L,
+            0x44b8edb239f2a141L, 0xb840cb37cfbeab59L, 0x0e9558adc0987ca2L, 0xc60442d5ff290606L,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo512Plus(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 8;
+        final XoShiRo512Plus rng = new XoShiRo512Plus(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo512Plus(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+            0x2af8df668d68ad55L, 0x76e56f59daa06243L, 0xf58c016f0f01e30fL, 0x8eeafa41683dbbf4L,
+        };
+        final XoShiRo512Plus rng1 = new XoShiRo512Plus(seed);
+        final XoShiRo512Plus rng2 = new XoShiRo512Plus(seed[0], seed[1], seed[2], seed[3],
+                                                       seed[4], seed[5], seed[6], seed[7]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo512StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/XoShiRo512StarStarTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XoShiRo512StarStarTest {
+    @Test
+    public void testReferenceCode() {
+        /*
+         * Data from running the executable compiled from the author's C code:
+         *   http://xoshiro.di.unimi.it/xoshiro512starstar.c
+         */
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+            0x2af8df668d68ad55L, 0x76e56f59daa06243L, 0xf58c016f0f01e30fL, 0x8eeafa41683dbbf4L,
+        };
+
+        final long[] expectedSequence = {
+            0x462c422df780c48eL, 0xa82f1f6031c183e6L, 0x60559add0e1e369aL, 0xf956a2b900083a8dL,
+            0x0e5c039df1576573L, 0x2f35cef71b14aa24L, 0x5809ea8aa1d5a045L, 0x3e695e3189ccf9bdL,
+            0x1eb940ee4bcb1a08L, 0x78b72a0927bd9257L, 0xe1a8e8d6dc64600bL, 0x3993bff6e1378a4bL,
+            0x439161ee3b5d5cc8L, 0xac6ca2359fe7f321L, 0xc4238c5785d320e2L, 0x75cf64526530aed5L,
+            0x679241ffc120e2b1L, 0xded30a8f20b24c73L, 0xff8ac62cff0deb9bL, 0xe63a25973df23c45L,
+            0x74742f9096c56401L, 0xc573afa2368288acL, 0x9b1048cf2daf9f9dL, 0xe7d9720c2f51ca5fL,
+            0x38a21e1f7a441cedL, 0x78835d75a9bd17a6L, 0xeb64167a723de35fL, 0x9455dd663e40620cL,
+            0x88693a769f203ed1L, 0xea5f0997a281cffcL, 0x2662b83f835f3273L, 0x5e90efde2150ed04L,
+            0xd481b14551c8f8d9L, 0xf2e4d714a0ab22d7L, 0xdfb1a8f0637a2013L, 0x8cd8d8c353640028L,
+            0xb4ce3b66785e0cc6L, 0xa51386e09b6ab734L, 0xfeac4151ac4a3f8dL, 0x0e5679853ab5180bL,
+        };
+
+        RandomAssert.assertEquals(expectedSequence, new XoShiRo512StarStar(seed));
+    }
+
+    @Test
+    public void testConstructorWithZeroSeed() {
+        // This is allowed even though the generator is non-functional
+        final int size = 8;
+        final XoShiRo512StarStar rng = new XoShiRo512StarStar(new long[size]);
+        for (int i = size * 2; i-- != 0; ) {
+            Assert.assertEquals("Expected the generator to be broken", 0L, rng.nextLong());
+        }
+    }
+
+    @Test
+    public void testConstructorWithoutFullLengthSeed() {
+        // Hit the case when the input seed is self-seeded when not full length
+        new XoShiRo512StarStar(new long[] { 0x012de1babb3c4104L });
+    }
+
+    @Test
+    public void testElementConstructor() {
+        final long[] seed = {
+            0x012de1babb3c4104L, 0xa5a818b8fc5aa503L, 0xb124ea2b701f4993L, 0x18e0374933d8c782L,
+            0x2af8df668d68ad55L, 0x76e56f59daa06243L, 0xf58c016f0f01e30fL, 0x8eeafa41683dbbf4L,
+        };
+        final XoShiRo512StarStar rng1 = new XoShiRo512StarStar(seed);
+        final XoShiRo512StarStar rng2 = new XoShiRo512StarStar(seed[0], seed[1], seed[2], seed[3],
+                                                               seed[4], seed[5], seed[6], seed[7]);
+        for (int i = seed.length * 2; i-- != 0; ) {
+            Assert.assertEquals(rng1.nextLong(), rng2.nextLong());
+        }
+    }
+}

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/RandomSource.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/RandomSource.java
@@ -307,6 +307,86 @@ public enum RandomSource {
      * </ul>
      */
     XOR_SHIFT_1024_S_PHI(ProviderBuilder.RandomSourceInternal.XOR_SHIFT_1024_S_PHI),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source32.XoRoShiRo64Star}.
+     * <ul>
+     *  <li>Native seed type: {@code int[]}.</li>
+     *  <li>Native seed size: 2.</li>
+     * </ul>
+     */
+    XO_RO_SHI_RO_64_S(ProviderBuilder.RandomSourceInternal.XO_RO_SHI_RO_64_S),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source32.XoRoShiRo64StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code int[]}.</li>
+     *  <li>Native seed size: 2.</li>
+     * </ul>
+     */
+    XO_RO_SHI_RO_64_SS(ProviderBuilder.RandomSourceInternal.XO_RO_SHI_RO_64_SS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source32.XoShiRo128Plus}.
+     * <ul>
+     *  <li>Native seed type: {@code int[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     */
+    XO_SHI_RO_128_PLUS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_128_PLUS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source32.XoShiRo128StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code int[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     */
+    XO_SHI_RO_128_SS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_128_SS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoRoShiRo128Plus}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 2.</li>
+     * </ul>
+     */
+    XO_RO_SHI_RO_128_PLUS(ProviderBuilder.RandomSourceInternal.XO_RO_SHI_RO_128_PLUS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoRoShiRo128StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 2.</li>
+     * </ul>
+     */
+    XO_RO_SHI_RO_128_SS(ProviderBuilder.RandomSourceInternal.XO_RO_SHI_RO_128_SS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoShiRo256Plus}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     */
+    XO_SHI_RO_256_PLUS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_256_PLUS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoShiRo256StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     */
+    XO_SHI_RO_256_SS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_256_SS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoShiRo512Plus}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 8.</li>
+     * </ul>
+     */
+    XO_SHI_RO_512_PLUS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_512_PLUS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.XoShiRo512StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 8.</li>
+     * </ul>
+     */
+    XO_SHI_RO_512_SS(ProviderBuilder.RandomSourceInternal.XO_SHI_RO_512_SS),
     ;
 
     /** Internal identifier. */

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
@@ -37,11 +37,21 @@ import org.apache.commons.rng.core.source32.ISAACRandom;
 import org.apache.commons.rng.core.source32.MersenneTwister;
 import org.apache.commons.rng.core.source32.MultiplyWithCarry256;
 import org.apache.commons.rng.core.source32.KISSRandom;
+import org.apache.commons.rng.core.source32.XoRoShiRo64Star;
+import org.apache.commons.rng.core.source32.XoRoShiRo64StarStar;
+import org.apache.commons.rng.core.source32.XoShiRo128Plus;
+import org.apache.commons.rng.core.source32.XoShiRo128StarStar;
 import org.apache.commons.rng.core.source64.SplitMix64;
 import org.apache.commons.rng.core.source64.XorShift1024Star;
 import org.apache.commons.rng.core.source64.XorShift1024StarPhi;
 import org.apache.commons.rng.core.source64.TwoCmres;
 import org.apache.commons.rng.core.source64.MersenneTwister64;
+import org.apache.commons.rng.core.source64.XoRoShiRo128Plus;
+import org.apache.commons.rng.core.source64.XoRoShiRo128StarStar;
+import org.apache.commons.rng.core.source64.XoShiRo256Plus;
+import org.apache.commons.rng.core.source64.XoShiRo256StarStar;
+import org.apache.commons.rng.core.source64.XoShiRo512Plus;
+import org.apache.commons.rng.core.source64.XoShiRo512StarStar;
 
 /**
  * RNG builder.
@@ -314,6 +324,36 @@ public final class ProviderBuilder {
         /** Source of randomness is {@link XorShift1024StarPhi}. */
         XOR_SHIFT_1024_S_PHI(XorShift1024StarPhi.class,
                              long[].class),
+        /** Source of randomness is {@link XoRoShiRo64Star}. */
+        XO_RO_SHI_RO_64_S(XoRoShiRo64Star.class,
+                          int[].class),
+        /** Source of randomness is {@link XoRoShiRo64StarStar}. */
+        XO_RO_SHI_RO_64_SS(XoRoShiRo64StarStar.class,
+                           int[].class),
+        /** Source of randomness is {@link XoShiRo128Plus}. */
+        XO_SHI_RO_128_PLUS(XoShiRo128Plus.class,
+                           int[].class),
+        /** Source of randomness is {@link XoShiRo128StarStar}. */
+        XO_SHI_RO_128_SS(XoShiRo128StarStar.class,
+                         int[].class),
+        /** Source of randomness is {@link XoRoShiRo128Plus}. */
+        XO_RO_SHI_RO_128_PLUS(XoRoShiRo128Plus.class,
+                              long[].class),
+        /** Source of randomness is {@link XoRoShiRo128StarStar}. */
+        XO_RO_SHI_RO_128_SS(XoRoShiRo128StarStar.class,
+                            long[].class),
+        /** Source of randomness is {@link XoShiRo256Plus}. */
+        XO_SHI_RO_256_PLUS(XoShiRo256Plus.class,
+                           long[].class),
+        /** Source of randomness is {@link XoShiRo256StarStar}. */
+        XO_SHI_RO_256_SS(XoShiRo256StarStar.class,
+                         long[].class),
+        /** Source of randomness is {@link XoShiRo512Plus}. */
+        XO_SHI_RO_512_PLUS(XoShiRo512Plus.class,
+                           long[].class),
+        /** Source of randomness is {@link XoShiRo512StarStar}. */
+        XO_SHI_RO_512_SS(XoShiRo512StarStar.class,
+                         long[].class),
         ;
 
         /** Source type. */

--- a/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ProvidersList.java
+++ b/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ProvidersList.java
@@ -52,6 +52,10 @@ public class ProvidersList {
             add(LIST32, RandomSource.ISAAC, new int[] { 123, -234, 345, -456 });
             add(LIST32, RandomSource.MWC_256, new int[] { 12, -1234, -3456, 45678 });
             add(LIST32, RandomSource.KISS, new int[] { 12, 1234, 23456, 345678 });
+            add(LIST32, RandomSource.XO_RO_SHI_RO_64_S, new int[] { 42, 12345 });
+            add(LIST32, RandomSource.XO_RO_SHI_RO_64_SS, new int[] { 78942, 134 });
+            add(LIST32, RandomSource.XO_SHI_RO_128_PLUS, new int[] { 565642, 1234, 4534 });
+            add(LIST32, RandomSource.XO_SHI_RO_128_SS, new int[] { 89, 1234, 6787 });
             // ... add more here.
 
             // "long"-based RNGs.
@@ -61,6 +65,12 @@ public class ProvidersList {
             add(LIST64, RandomSource.TWO_CMRES, 55443322);
             add(LIST64, RandomSource.TWO_CMRES_SELECT, -987654321, 5, 8);
             add(LIST64, RandomSource.MT_64, new long[] { 1234567L, 2345678L, -3456789L });
+            add(LIST64, RandomSource.XO_RO_SHI_RO_128_PLUS, new long[] { 55646L, -456659L, 565656L });
+            add(LIST64, RandomSource.XO_RO_SHI_RO_128_SS, new long[] { 45655L, 5454544L, 4564659L });
+            add(LIST64, RandomSource.XO_SHI_RO_256_PLUS, new long[] { 11222L, -568989L, -456789L });
+            add(LIST64, RandomSource.XO_SHI_RO_256_SS, new long[] { 98765L, -2345678L, -3456789L });
+            add(LIST64, RandomSource.XO_SHI_RO_512_PLUS, new long[] { 89932L, -545669L, 4564689L });
+            add(LIST64, RandomSource.XO_SHI_RO_512_SS, new long[] { 123L, -654654L, 45646789L });
             // ... add more here.
 
             // Do not modify the remaining statements.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -75,6 +75,11 @@ re-run tests that fail, and pass the build if they succeed
 within the allotted number of reruns (the test will be marked
 as 'flaky' in the report).
 ">
+      <action dev="aherbert" type="add" issue="RNG-70">
+        New "XorShiRo" family of generators. This adds 6 new general purpose generators with
+        different periods and 4 related generators with improved performance for floating-point
+        generation.
+      </action>
       <action dev="aherbert" type="update" issue="RNG-88">
         Update the generation performance JMH benchmarks to have a reference baseline.
       </action>


### PR DESCRIPTION
Please review.

Generators have been created to match their reference implementation. 

This change incorporates modification of the existing ``XorShift1024Star`` class to enable the slightly different ``XorShift1024StarPhi``to inherit all functionality. That change can be moved to a diffferent PR if required.

The design moves common code for save/restore to abstract classes. However the amount of code is small and the abstract classes could be dropped is favour of code duplication to reduce the number of extra abstract classes.

If a seed is provided with all zeros then the generators are broken. A test asserts that this is allowed.

I have only modified the projects core and simple. Further changes to the other projects to add the extra providers will be required when accepted.
