### PR TITLE
RNG-71: Validate parameters for the distribution samplers

### DIFF
--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSampler.java
@@ -64,10 +64,14 @@ public class AhrensDieterExponentialSampler
     /**
      * @param rng Generator of uniformly distributed random numbers.
      * @param mean Mean of this distribution.
+     * @throws IllegalArgumentException if {@code mean <= 0}
      */
     public AhrensDieterExponentialSampler(UniformRandomProvider rng,
                                           double mean) {
         super(null);
+        if (mean <= 0) {
+            throw new IllegalArgumentException("mean is not strictly positive: " + mean);
+        }
         this.rng = rng;
         this.mean = mean;
     }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSampler.java
@@ -64,10 +64,17 @@ public class AhrensDieterMarsagliaTsangGammaSampler
          * @param rng Generator of uniformly distributed random numbers.
          * @param alpha Alpha shape parameter of the distribution.
          * @param theta Theta scale parameter of the distribution.
+         * @throws IllegalArgumentException if {@code alpha <= 0} or {@code theta <= 0}
          */
         BaseAhrensDieterMarsagliaTsangGammaSampler(UniformRandomProvider rng,
                                                    double alpha,
                                                    double theta) {
+            if (alpha <= 0) {
+                throw new IllegalArgumentException("alpha is not strictly positive: " + alpha);
+            }
+            if (theta <= 0) {
+                throw new IllegalArgumentException("theta is not strictly positive: " + theta);
+            }
             this.rng = rng;
             this.alpha = alpha;
             this.theta = theta;
@@ -95,6 +102,7 @@ public class AhrensDieterMarsagliaTsangGammaSampler
          * @param rng Generator of uniformly distributed random numbers.
          * @param alpha Alpha shape parameter of the distribution.
          * @param theta Theta scale parameter of the distribution.
+         * @throws IllegalArgumentException if {@code alpha <= 0} or {@code theta <= 0}
          */
         SmallThetaAhrensDieterMarsagliaTsangGammaSampler(UniformRandomProvider rng,
                                                          double alpha,
@@ -158,6 +166,7 @@ public class AhrensDieterMarsagliaTsangGammaSampler
          * @param rng Generator of uniformly distributed random numbers.
          * @param alpha Alpha shape parameter of the distribution.
          * @param theta Theta scale parameter of the distribution.
+         * @throws IllegalArgumentException if {@code alpha <= 0} or {@code theta <= 0}
          */
         LargeThetaAhrensDieterMarsagliaTsangGammaSampler(UniformRandomProvider rng,
                                                          double alpha,
@@ -198,6 +207,7 @@ public class AhrensDieterMarsagliaTsangGammaSampler
      * @param rng Generator of uniformly distributed random numbers.
      * @param alpha Alpha shape parameter of the distribution.
      * @param theta Theta scale parameter of the distribution.
+     * @throws IllegalArgumentException if {@code alpha <= 0} or {@code theta <= 0}
      */
     public AhrensDieterMarsagliaTsangGammaSampler(UniformRandomProvider rng,
                                                   double alpha,

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSampler.java
@@ -44,11 +44,16 @@ public class BoxMullerGaussianSampler
      * @param rng Generator of uniformly distributed random numbers.
      * @param mean Mean of the Gaussian distribution.
      * @param standardDeviation Standard deviation of the Gaussian distribution.
+     * @throws IllegalArgumentException if {@code standardDeviation <= 0}
      */
     public BoxMullerGaussianSampler(UniformRandomProvider rng,
                                     double mean,
                                     double standardDeviation) {
         super(null);
+        if (standardDeviation <= 0) {
+            throw new IllegalArgumentException("standard deviation is not strictly positive: " +
+                standardDeviation);
+        }
         this.rng = rng;
         this.mean = mean;
         this.standardDeviation = standardDeviation;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSampler.java
@@ -38,6 +38,7 @@ public class BoxMullerLogNormalSampler
      * @param rng Generator of uniformly distributed random numbers.
      * @param scale Scale of the log-normal distribution.
      * @param shape Shape of the log-normal distribution.
+     * @throws IllegalArgumentException if {@code scale < 0} or {@code shape <= 0}.
      */
     public BoxMullerLogNormalSampler(UniformRandomProvider rng,
                                      double scale,

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ChengBetaSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ChengBetaSampler.java
@@ -47,11 +47,18 @@ public class ChengBetaSampler
      * @param rng Generator of uniformly distributed random numbers.
      * @param alpha Distribution first shape parameter.
      * @param beta Distribution second shape parameter.
+     * @throws IllegalArgumentException if {@code alpha <= 0} or {@code beta <= 0}
      */
     public ChengBetaSampler(UniformRandomProvider rng,
                             double alpha,
                             double beta) {
         super(null);
+        if (alpha <= 0) {
+            throw new IllegalArgumentException("alpha is not strictly positive: " + alpha);
+        }
+        if (beta <= 0) {
+            throw new IllegalArgumentException("beta is not strictly positive: " + beta);
+        }
         this.rng = rng;
         alphaShape = alpha;
         betaShape = beta;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/GaussianSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/GaussianSampler.java
@@ -34,10 +34,15 @@ public class GaussianSampler implements ContinuousSampler {
      * @param normalized Generator of N(0,1) Gaussian distributed random numbers.
      * @param mean Mean of the Gaussian distribution.
      * @param standardDeviation Standard deviation of the Gaussian distribution.
+     * @throws IllegalArgumentException if {@code standardDeviation <= 0}
      */
     public GaussianSampler(NormalizedGaussianSampler normalized,
                            double mean,
                            double standardDeviation) {
+        if (standardDeviation <= 0) {
+            throw new IllegalArgumentException(
+                "standard deviation is not strictly positive: " + standardDeviation);
+        }
         this.normalized = normalized;
         this.mean = mean;
         this.standardDeviation = standardDeviation;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSampler.java
@@ -37,11 +37,18 @@ public class InverseTransformParetoSampler
      * @param rng Generator of uniformly distributed random numbers.
      * @param scale Scale of the distribution.
      * @param shape Shape of the distribution.
+     * @throws IllegalArgumentException if {@code scale <= 0} or {@code shape <= 0}
      */
     public InverseTransformParetoSampler(UniformRandomProvider rng,
                                          double scale,
                                          double shape) {
         super(null);
+        if (scale <= 0) {
+            throw new IllegalArgumentException("scale is not strictly positive: " + scale);
+        }
+        if (shape <= 0) {
+            throw new IllegalArgumentException("shape is not strictly positive: " + shape);
+        }
         this.rng = rng;
         this.scale = scale;
         this.shape = shape;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
@@ -104,11 +104,11 @@ public class LargeMeanPoissonSampler
     public LargeMeanPoissonSampler(UniformRandomProvider rng,
                                    double mean) {
         if (mean <= 0) {
-          throw new IllegalArgumentException(mean + " <= " + 0);
+            throw new IllegalArgumentException("mean is not strictly positive: " + mean);
         }
         // The algorithm is not valid if Math.floor(mean) is not an integer.
         if (mean > MAX_MEAN) {
-            throw new IllegalArgumentException(mean + " > " + MAX_MEAN);
+            throw new IllegalArgumentException("mean " + mean + " > " + MAX_MEAN);
         }
         this.rng = rng;
 

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LogNormalSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LogNormalSampler.java
@@ -33,10 +33,17 @@ public class LogNormalSampler implements ContinuousSampler {
      * @param gaussian N(0,1) generator.
      * @param scale Scale of the log-normal distribution.
      * @param shape Shape of the log-normal distribution.
+     * @throws IllegalArgumentException if {@code scale < 0} or {@code shape <= 0}.
      */
     public LogNormalSampler(NormalizedGaussianSampler gaussian,
                             double scale,
                             double shape) {
+        if (scale < 0) {
+            throw new IllegalArgumentException("scale is not positive: " + scale);
+        }
+        if (shape <= 0) {
+            throw new IllegalArgumentException("shape is not strictly positive: " + shape);
+        }
         this.scale = scale;
         this.shape = shape;
         this.gaussian = gaussian;

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
@@ -51,16 +51,17 @@ public class SmallMeanPoissonSampler
     /**
      * @param rng  Generator of uniformly distributed random numbers.
      * @param mean Mean.
-     * @throws IllegalArgumentException if {@code mean <= 0}.
+     * @throws IllegalArgumentException if {@code mean <= 0} or
+     * {@code mean > 0.5 *} {@link Integer#MAX_VALUE}.
      */
     public SmallMeanPoissonSampler(UniformRandomProvider rng,
                                    double mean) {
         this.rng = rng;
         if (mean <= 0) {
-            throw new IllegalArgumentException(mean + " <= " + 0);
+            throw new IllegalArgumentException("mean is not strictly positive: " + mean);
         }
         if (mean > MAX_MEAN) {
-            throw new IllegalArgumentException(mean + " > " + MAX_MEAN);
+            throw new IllegalArgumentException("mean " + mean + " > " + MAX_MEAN);
         }
 
         p0 = Math.exp(-mean);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
@@ -21,21 +21,9 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link AhrensDieterExponentialSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
-    /**
-     * Test the constructor with a bad mean.
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
-        final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
-        @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
-    }
-
+public class AhrensDieterExponentialSamplerTest {
     /**
      * Test the constructor with a bad mean.
      */
@@ -45,6 +33,7 @@ public class SmallMeanPoissonSamplerTest {
             RandomSource.create(RandomSource.SPLIT_MIX_64);
         final double mean = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final AhrensDieterExponentialSampler sampler =
+            new AhrensDieterExponentialSampler(rng, mean);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
@@ -21,30 +21,34 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link AhrensDieterMarsagliaTsangGammaSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class AhrensDieterMarsagliaTsangGammaSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad alpha.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroAlpha() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final double alpha = 0;
+        final double theta = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final AhrensDieterMarsagliaTsangGammaSampler sampler =
+            new AhrensDieterMarsagliaTsangGammaSampler(rng, alpha, theta);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad theta.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroTheta() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final double alpha = 1;
+        final double theta = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final AhrensDieterMarsagliaTsangGammaSampler sampler =
+            new AhrensDieterMarsagliaTsangGammaSampler(rng, alpha, theta);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSamplerTest.java
@@ -21,30 +21,20 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link BoxMullerGaussianSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class BoxMullerGaussianSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad standard deviation.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroStandardDeviation() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final double mean = 1;
+        final double standardDeviation = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
-    }
-
-    /**
-     * Test the constructor with a bad mean.
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
-        final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
-        @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final BoxMullerGaussianSampler sampler =
+            new BoxMullerGaussianSampler(rng, mean, standardDeviation);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSamplerTest.java
@@ -21,30 +21,34 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link BoxMullerLogNormalSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class BoxMullerLogNormalSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad scale.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithNegativeScale() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final double scale = -1e-6;
+        final double shape = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final BoxMullerLogNormalSampler sampler =
+            new BoxMullerLogNormalSampler(rng, scale, shape);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad shape.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final double scale = 1;
+        final double shape = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final BoxMullerLogNormalSampler sampler =
+            new BoxMullerLogNormalSampler(rng, scale, shape);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
@@ -21,30 +21,34 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link ChengBetaSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class ChengBetaSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad alpha.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroAlpha() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final double alpha = 0;
+        final double beta = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final ChengBetaSampler sampler =
+            new ChengBetaSampler(rng, alpha, beta);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad beta.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroBeta() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final double alpha = 1;
+        final double beta = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final ChengBetaSampler sampler =
+            new ChengBetaSampler(rng, alpha, beta);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSamplerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for the {@link ContinuousUniformSampler}.
+ */
+public class ContinuousUniformSamplerTest {
+    /**
+     * Test that the sampler algorithm does not require high to be above low.
+     */
+    @Test
+    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
+        // Note: This 
+        final double low = 3.18;
+        final double high = 5.23;
+        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        testSampleInRange(rng, low, high);
+        testSampleInRange(rng, high, low);
+    }
+
+    private static void testSampleInRange(UniformRandomProvider rng, 
+                                          double low, double high) {
+        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
+        final double min = Math.min(low,  high);
+        final double max = Math.max(low,  high);
+        for (int i = 0; i < 10; i++) {
+            final double value = sampler.sample();
+            Assert.assertTrue("Value not in range", value >= min && value <= max);
+        }
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
@@ -16,35 +16,23 @@
  */
 package org.apache.commons.rng.sampling.distribution;
 
-import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link DiscreteUniformSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class DiscreteUniformSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad range.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
-        final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+    public void testConstructorThrowsWithLowerAboveUpper() {
+        final int upper = 55;
+        final int lower = upper + 1;
+        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
-    }
-
-    /**
-     * Test the constructor with a bad mean.
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
-        final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
-        @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        DiscreteUniformSampler sampler = new DiscreteUniformSampler(rng, lower, upper);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
@@ -21,30 +21,21 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link GaussianSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class GaussianSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad standard deviation.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroStandardDeviation() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
+        final double mean = 1;
+        final double standardDeviation = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
-    }
-
-    /**
-     * Test the constructor with a bad mean.
-     */
-    @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
-        final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
-        @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final GaussianSampler sampler =
+            new GaussianSampler(gauss, mean, standardDeviation);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
@@ -17,7 +17,6 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.core.source64.SplitMix64;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +45,7 @@ public class GeometricSamplerTest {
      */
     @Test
     public void testProbabilityOfSuccessIsOneSamplerToString() {
-        final UniformRandomProvider unusedRng = new SplitMix64(0L);
+        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
         final GeometricSampler sampler = new GeometricSampler(unusedRng, 1);
         Assert.assertTrue("Missing 'Geometric' from toString",
             sampler.toString().contains("Geometric"));
@@ -75,20 +74,22 @@ public class GeometricSamplerTest {
     /**
      * Test probability of success {@code >1} is not allowed.
      */
-    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testProbabilityOfSuccessAboveOneThrows() {
-        final UniformRandomProvider unusedRng = new SplitMix64(0L);
-        new GeometricSampler(unusedRng, Math.nextUp(1.0));
+        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final double probabilityOfSuccess = Math.nextUp(1.0);
+        @SuppressWarnings("unused")
+        final GeometricSampler sampler = new GeometricSampler(unusedRng, probabilityOfSuccess);
     }
 
     /**
      * Test probability of success {@code 0} is not allowed.
      */
-    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testProbabilityOfSuccessIsZeroThrows() {
-        final UniformRandomProvider unusedRng = new SplitMix64(0L);
-        new GeometricSampler(unusedRng, 0);
+        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final double probabilityOfSuccess = 0;
+        @SuppressWarnings("unused")
+        final GeometricSampler sampler = new GeometricSampler(unusedRng, probabilityOfSuccess);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
@@ -21,30 +21,34 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link InverseTransformParetoSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class InverseTransformParetoSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad scale.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroScale() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final double shape = 1;
+        final double scale = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final InverseTransformParetoSampler sampler =
+            new InverseTransformParetoSampler(rng, shape, scale);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad shape.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final double shape = 0;
+        final double scale = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final InverseTransformParetoSampler sampler =
+            new InverseTransformParetoSampler(rng, shape, scale);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
@@ -38,8 +38,9 @@ public class LargeMeanPoissonSamplerTest {
     public void testConstructorThrowsWithMeanLargerThanUpperBound() {
         final RestorableUniformRandomProvider rng =
                 RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final double mean = Integer.MAX_VALUE / 2 + 1;
         @SuppressWarnings("unused")
-        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, Integer.MAX_VALUE / 2 + 1);
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, mean);
     }
 
     /**
@@ -49,8 +50,9 @@ public class LargeMeanPoissonSamplerTest {
     public void testConstructorThrowsWithZeroMean() {
         final RestorableUniformRandomProvider rng =
                 RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final double mean = 0;
         @SuppressWarnings("unused")
-        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, 0);
+        LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, mean);
     }
 
     /**
@@ -121,7 +123,6 @@ public class LargeMeanPoissonSamplerTest {
      *
      * @param rng1  the first random provider
      * @param rng2  the second random provider
-     * @param cache the cache
      * @param mean  the mean
      */
     private static void testPoissonSamples(
@@ -136,7 +137,8 @@ public class LargeMeanPoissonSamplerTest {
         final LargeMeanPoissonSamplerState state2 = ((LargeMeanPoissonSampler)s2).getState();
         Assert.assertEquals("State lambdas are not equal", state1.getLambda(), state2.getLambda());
         Assert.assertNotSame("States are the same object", state1, state2);
-        for (int j = 0; j < 10; j++)
+        for (int j = 0; j < 10; j++) {
             Assert.assertEquals("Not the same sample", s1.sample(), s2.sample());
+        }
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LogNormalSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LogNormalSamplerTest.java
@@ -21,30 +21,36 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link LogNormalSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class LogNormalSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad shape.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithNegativeScale() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
+        final double scale = -1e-6;
+        final double shape = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final LogNormalSampler sampler =
+            new LogNormalSampler(gauss, scale, shape);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad shape.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
+        final double scale = 1;
+        final double shape = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final LogNormalSampler sampler =
+            new LogNormalSampler(gauss, scale, shape);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
@@ -21,30 +21,34 @@ import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
 /**
- * Test for the {@link SmallMeanPoissonSampler}. The tests hit edge cases for the sampler.
+ * Test for the {@link RejectionInversionZipfSampler}. The tests hit edge cases for the sampler.
  */
-public class SmallMeanPoissonSamplerTest {
+public class RejectionInversionZipfSamplerTest {
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad number of elements.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+    public void testConstructorThrowsWithZeroNumberOfElements() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = Integer.MAX_VALUE / 2 + 1;
+        final int numberOfElements = 0;
+        final double exponent = 1;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final RejectionInversionZipfSampler sampler =
+            new RejectionInversionZipfSampler(rng, numberOfElements, exponent);
     }
 
     /**
-     * Test the constructor with a bad mean.
+     * Test the constructor with a bad exponent.
      */
     @Test(expected=IllegalArgumentException.class)
-    public void testConstructorThrowsWithZeroMean() {
+    public void testConstructorThrowsWithZeroExponent() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double mean = 0;
+        final int numberOfElements = 1;
+        final double exponent = 0;
         @SuppressWarnings("unused")
-        SmallMeanPoissonSampler sampler = new SmallMeanPoissonSampler(rng, mean);
+        final RejectionInversionZipfSampler sampler =
+            new RejectionInversionZipfSampler(rng, numberOfElements, exponent);
     }
 }


### PR DESCRIPTION
This adds checks matching those found in the commons-math3 distributions
to the samplers. An additional check missing in commons-math3 was added to the `LogNormalSampler` to ensure the mean (scale) parameter was positive. I am unsure why this check is missing in CM as it is defined here [Log-normal_distribution](https://en.wikipedia.org/wiki/Log-normal_distribution).

The existing validation checks in the PoissonSampler
have had their exception messages changed for consistency across all the samplers.

A test for
the ContinuousUniformSampler was added to demonstrate no range checks
are required.