### PR TITLE
Update readme using commons-build-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -45,28 +45,32 @@ Apache Commons RNG
 
 [![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
 [![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-parent/)
-[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-parent/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-parent/1.2)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-simple/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-simple/1.2)
 
 The Apache Commons RNG project provides pure-Java implementation of pseudo-random generators.
 
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng). The Javadoc for each of the modules can be browsed:
+
+- [Commons RNG Core](https://commons.apache.org/proper/commons-rng/commons-rng-core/apidocs/)
+- [Commons RNG Simple](https://commons.apache.org/proper/commons-rng/commons-rng-simple/apidocs/)
+- [Commons RNG Sampling](https://commons.apache.org/proper/commons-rng/commons-rng-sampling/apidocs/)
+
 Questions related to the usage of Apache Commons RNG should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
 You can download source and binaries from our [download page](https://commons.apache.org/proper/commons-rng/download_rng.cgi).
 
-Alternatively you can pull it from the central Maven repositories:
+Alternatively you can pull it from the central Maven repositories, e.g.:
 
 ```xml
 <dependency>
   <groupId>org.apache.commons</groupId>
-  <artifactId>commons-rng-parent</artifactId>
+  <artifactId>commons-rng-simple</artifactId>
   <version>1.2</version>
 </dependency>
 ```
@@ -92,12 +96,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Documentation
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng). The Javadoc for each of the modules can be browsed:
 
+- [Commons RNG Client API](https://commons.apache.org/proper/commons-rng/commons-rng-client-api/apidocs/)
 - [Commons RNG Core](https://commons.apache.org/proper/commons-rng/commons-rng-core/apidocs/)
 - [Commons RNG Simple](https://commons.apache.org/proper/commons-rng/commons-rng-simple/apidocs/)
 - [Commons RNG Sampling](https://commons.apache.org/proper/commons-rng/commons-rng-sampling/apidocs/)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Alternatively you can pull it from the central Maven repositories, e.g.:
   <artifactId>commons-rng-simple</artifactId>
   <version>1.2</version>
 </dependency>
+<dependency>
+  <groupId>org.apache.commons</groupId>
+  <artifactId>commons-rng-sampling</artifactId>
+  <version>1.2</version>
+</dependency>
 ```
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>rng</commons.componentid>                    |
- |    <commons.release.version>1.0</commons.release.version>            |
+ |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
  +======================================================================+
@@ -43,19 +43,18 @@
 Apache Commons RNG
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng.svg?branch=master)](https://travis-ci.org/apache/commons-rng)
-[![Coverage Status](https://coveralls.io/repos/github/apache/commons-rng/badge.svg?branch=master)](https://coveralls.io/github/apache/commons-rng?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-sampling/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-sampling/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-parent/)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-parent/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-parent/1.2)
 
-The Apache Commons RNG project provides Java implementations of pseudo-random numbers generators.
+The Apache Commons RNG project provides pure-Java implementation of pseudo-random generators.
 
 Documentation
 -------------
 
-More information can be found on the [homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/apidocs) can be browsed.
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
+The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
@@ -67,15 +66,15 @@ Alternatively you can pull it from the central Maven repositories:
 ```xml
 <dependency>
   <groupId>org.apache.commons</groupId>
-  <artifactId>commons-rng</artifactId>
-  <version>1.1</version>
+  <artifactId>commons-rng-parent</artifactId>
+  <version>1.2</version>
 </dependency>
 ```
 
 Contributing
 ------------
 
-We accept PRs via github. The [developer mailing list][ml] is the main channel of communication for contributors.
+We accept Pull Requests via GitHub. The [developer mailing list][ml] is the main channel of communication for contributors.
 There are some guidelines which will make applying PRs easier for us:
 + No tabs! Please use spaces for indentation.
 + Respect the code style.
@@ -87,7 +86,9 @@ You can learn more about contributing via GitHub in our [contribution guidelines
 
 License
 -------
-Code is under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.0.txt).
+This code is under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.0).
+
+See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
@@ -97,8 +98,8 @@ Additional Resources
 --------------------
 
 + [Apache Commons Homepage](https://commons.apache.org/)
-+ [Apache Bugtracker (JIRA)](https://issues.apache.org/jira/)
++ [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
-+ #apachecommons IRC channel on freenode.org
++ `#apache-commons` IRC channel on `irc.freenode.org`
 
 [ml]:https://commons.apache.org/mail-lists.html

--- a/commons-rng-client-api/README.md
+++ b/commons-rng-client-api/README.md
@@ -43,10 +43,10 @@
 Apache Commons RNG Client API
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-client-api.svg?branch=master)](https://travis-ci.org/apache/commons-rng-client-api)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-client-api/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-client-api)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-client-api/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-client-api/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-client-api/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-client-api/1.2)
 
 API for client code that uses random numbers generators.
 
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-client-api</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-client-api/README.md
+++ b/commons-rng-client-api/README.md
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-client-api/README.md
+++ b/commons-rng-client-api/README.md
@@ -97,7 +97,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-client-api/README.md
+++ b/commons-rng-client-api/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-client-api/apidocs/) can be browsed.
 Questions related to the usage of Apache Commons RNG Client API should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-client-api/README.md
+++ b/commons-rng-client-api/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -53,7 +53,7 @@ API for client code that uses random numbers generators.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Client API homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG Client API should be posted to the [user mailing list][ml].
 
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Client API? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-core/README.md
+++ b/commons-rng-core/README.md
@@ -43,12 +43,16 @@
 Apache Commons RNG Core
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-core.svg?branch=master)](https://travis-ci.org/apache/commons-rng-core)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-core/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-core)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-core/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-core/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-core/1.2)
 
 Pure Java implementations of random numbers generator algorithms.
+  Code in this module should not be used directly by applications; please use
+  the client interface defined in module "commons-rng-client-api" and the factory
+  methods defined in module "commons-rng-simple". In a future release, modularization
+  may be enforced through JPMS access restrictions.
 
 Documentation
 -------------
@@ -67,7 +71,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-core</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-core/README.md
+++ b/commons-rng-core/README.md
@@ -101,7 +101,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-core/README.md
+++ b/commons-rng-core/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -57,7 +57,7 @@ Pure Java implementations of random numbers generator algorithms.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Core homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG Core should be posted to the [user mailing list][ml].
 
@@ -96,12 +96,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Core? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-core/README.md
+++ b/commons-rng-core/README.md
@@ -58,7 +58,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-core/apidocs/) can be browsed.
 Questions related to the usage of Apache Commons RNG Core should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-core/README.md
+++ b/commons-rng-core/README.md
@@ -96,12 +96,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -43,13 +43,15 @@
 Apache Commons RNG Examples
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples/1.2)
 
-Examples of use of the random numbers generator implemented in the "commons-rng-simple" module.
-  Code in this module is not part of the public API.
+Examples of use of the "Commons RNG" library.
+  Codes in this module and its sub-modules are not part of the library.
+  They provide checking, benchmarking tools to enhance the documentation
+  and to help ensure correctness of the implementations.
 
 Documentation
 -------------
@@ -68,7 +70,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -56,7 +56,7 @@ Examples of use of the "Commons RNG" library.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Examples homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG Examples should be posted to the [user mailing list][ml].
 
@@ -95,12 +95,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Examples? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -57,7 +57,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples/apidocs/) can be browsed.
 Questions related to the usage of Apache Commons RNG Examples should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -95,12 +95,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -100,7 +100,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/README.md
+++ b/commons-rng-examples/README.md
@@ -46,7 +46,6 @@ Apache Commons RNG Examples
 [![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
 [![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples/)
-[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples/1.2)
 
 Examples of use of the "Commons RNG" library.
   Codes in this module and its sub-modules are not part of the library.

--- a/commons-rng-examples/examples-jmh/README.md
+++ b/commons-rng-examples/examples-jmh/README.md
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jmh/README.md
+++ b/commons-rng-examples/examples-jmh/README.md
@@ -55,7 +55,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-jmh/apidocs/) can be browsed.
 Questions related to the usage of JMH Benchmark should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-jmh/README.md
+++ b/commons-rng-examples/examples-jmh/README.md
@@ -98,7 +98,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jmh/README.md
+++ b/commons-rng-examples/examples-jmh/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -54,7 +54,7 @@ Code for running JMH benchmarks that assess the performance of the generators.
 Documentation
 -------------
 
-More information can be found on the [JMH Benchmark homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of JMH Benchmark should be posted to the [user mailing list][ml].
 
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like JMH Benchmark? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jmh/README.md
+++ b/commons-rng-examples/examples-jmh/README.md
@@ -40,13 +40,13 @@
  |                                                                      |
  +======================================================================+
 --->
-Apache Commons RNG JMH Benchmark
+JMH Benchmark
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-jmh.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-jmh)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-jmh/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-jmh)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jmh/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jmh/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-jmh/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-jmh/1.2)
 
 Code for running JMH benchmarks that assess the performance of the generators.
   Code in this module is not part of the public API.
@@ -54,9 +54,9 @@ Code for running JMH benchmarks that assess the performance of the generators.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG JMH Benchmark homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [JMH Benchmark homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
-Questions related to the usage of Apache Commons RNG JMH Benchmark should be posted to the [user mailing list][ml].
+Questions related to the usage of JMH Benchmark should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
@@ -68,7 +68,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-jmh</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG JMH Benchmark? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like JMH Benchmark? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------

--- a/commons-rng-examples/examples-jpms/README.md
+++ b/commons-rng-examples/examples-jpms/README.md
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/README.md
+++ b/commons-rng-examples/examples-jpms/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -53,7 +53,7 @@ Testing JPMS. Code in this module is not part of the public API.
 Documentation
 -------------
 
-More information can be found on the [JPMS Integration test homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of JPMS Integration test should be posted to the [user mailing list][ml].
 
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like JPMS Integration test? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/README.md
+++ b/commons-rng-examples/examples-jpms/README.md
@@ -97,7 +97,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/README.md
+++ b/commons-rng-examples/examples-jpms/README.md
@@ -40,22 +40,22 @@
  |                                                                      |
  +======================================================================+
 --->
-Apache Commons RNG Integration
+JPMS Integration test
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-jpms.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-jpms)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-jpms/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-jpms)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-jpms/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-jpms/1.2)
 
 Testing JPMS. Code in this module is not part of the public API.
 
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Integration homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [JPMS Integration test homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
-Questions related to the usage of Apache Commons RNG Integration should be posted to the [user mailing list][ml].
+Questions related to the usage of JPMS Integration test should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-jpms</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 
@@ -92,7 +92,7 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Integration? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like JPMS Integration test? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------

--- a/commons-rng-examples/examples-jpms/README.md
+++ b/commons-rng-examples/examples-jpms/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-jpms/apidocs/) can be browsed.
 Questions related to the usage of JPMS Integration test should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-jpms/jpms-app/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-app/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -53,7 +53,7 @@ Testing JPMS. Code in this module is not part of the public API.
 Documentation
 -------------
 
-More information can be found on the [JPMS module example (application) homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of JPMS module example (application) should be posted to the [user mailing list][ml].
 
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like JPMS module example (application)? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-app/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-app/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-jpms-app/apidocs/) can be browsed.
 Questions related to the usage of JPMS module example (application) should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-jpms/jpms-app/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-app/README.md
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-app/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-app/README.md
@@ -43,10 +43,10 @@
 JPMS module example (application)
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-jpms-app.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-jpms-app)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-jpms-app/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-jpms-app)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms-app/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms-app/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-jpms-app/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-jpms-app/1.2)
 
 Testing JPMS. Code in this module is not part of the public API.
 
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-jpms-app</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-examples/examples-jpms/jpms-app/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-app/README.md
@@ -97,7 +97,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-lib/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-lib/README.md
@@ -43,10 +43,10 @@
 JPMS module example (library)
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-jpms-lib.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-jpms-lib)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-jpms-lib/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-jpms-lib)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms-lib/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-jpms-lib/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-jpms-lib/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-jpms-lib/1.2)
 
 Testing JPMS. Code in this module is not part of the public API.
 
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-jpms-lib</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-examples/examples-jpms/jpms-lib/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-lib/README.md
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-lib/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-lib/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -53,7 +53,7 @@ Testing JPMS. Code in this module is not part of the public API.
 Documentation
 -------------
 
-More information can be found on the [JPMS module example (library) homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of JPMS module example (library) should be posted to the [user mailing list][ml].
 
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like JPMS module example (library)? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-lib/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-lib/README.md
@@ -97,7 +97,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-jpms/jpms-lib/README.md
+++ b/commons-rng-examples/examples-jpms/jpms-lib/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-jpms-lib/apidocs/) can be browsed.
 Questions related to the usage of JPMS module example (library) should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-quadrature/README.md
+++ b/commons-rng-examples/examples-quadrature/README.md
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-quadrature/README.md
+++ b/commons-rng-examples/examples-quadrature/README.md
@@ -98,7 +98,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-quadrature/README.md
+++ b/commons-rng-examples/examples-quadrature/README.md
@@ -55,7 +55,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-quadrature/apidocs/) can be browsed.
 Questions related to the usage of Quadrature example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-quadrature/README.md
+++ b/commons-rng-examples/examples-quadrature/README.md
@@ -40,13 +40,13 @@
  |                                                                      |
  +======================================================================+
 --->
-Apache Commons RNG Quadrature Test Example
+Quadrature example
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-quadrature.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-quadrature)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-quadrature/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-quadrature)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-quadrature/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-quadrature/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-quadrature/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-quadrature/1.2)
 
 Application for calling external tools that perform stringent uniformity tests.
   Code in this module is not part of the public API.
@@ -54,9 +54,9 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Quadrature Test Example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Quadrature example homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
-Questions related to the usage of Apache Commons RNG Quadrature Test Example should be posted to the [user mailing list][ml].
+Questions related to the usage of Quadrature example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
@@ -68,7 +68,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-quadrature</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Quadrature Test Example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Quadrature example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------

--- a/commons-rng-examples/examples-quadrature/README.md
+++ b/commons-rng-examples/examples-quadrature/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -54,7 +54,7 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Quadrature example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Quadrature example should be posted to the [user mailing list][ml].
 
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Quadrature example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-sampling/README.md
+++ b/commons-rng-examples/examples-sampling/README.md
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-sampling/README.md
+++ b/commons-rng-examples/examples-sampling/README.md
@@ -98,7 +98,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-sampling/README.md
+++ b/commons-rng-examples/examples-sampling/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -54,7 +54,7 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Sampling example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Sampling example should be posted to the [user mailing list][ml].
 
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Sampling example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-sampling/README.md
+++ b/commons-rng-examples/examples-sampling/README.md
@@ -40,13 +40,13 @@
  |                                                                      |
  +======================================================================+
 --->
-Apache Commons RNG Sampling Test Example
+Sampling example
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-sampling.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-sampling)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-sampling/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-sampling)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-sampling/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-sampling/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-sampling/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-sampling/1.2)
 
 Application for calling external tools that perform stringent uniformity tests.
   Code in this module is not part of the public API.
@@ -54,9 +54,9 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Sampling Test Example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Sampling example homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
-Questions related to the usage of Apache Commons RNG Sampling Test Example should be posted to the [user mailing list][ml].
+Questions related to the usage of Sampling example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
@@ -68,7 +68,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-sampling</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Sampling Test Example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Sampling example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------

--- a/commons-rng-examples/examples-sampling/README.md
+++ b/commons-rng-examples/examples-sampling/README.md
@@ -55,7 +55,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-sampling/apidocs/) can be browsed.
 Questions related to the usage of Sampling example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-stress/README.md
+++ b/commons-rng-examples/examples-stress/README.md
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-stress/README.md
+++ b/commons-rng-examples/examples-stress/README.md
@@ -40,13 +40,13 @@
  |                                                                      |
  +======================================================================+
 --->
-Apache Commons RNG Stress Test Example
+Stress test example
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-examples-stress.svg?branch=master)](https://travis-ci.org/apache/commons-rng-examples-stress)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-examples-stress/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-examples-stress)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-stress/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-examples-stress/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-examples-stress/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-examples-stress/1.2)
 
 Application for calling external tools that perform stringent uniformity tests.
   Code in this module is not part of the public API.
@@ -54,9 +54,9 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Stress Test Example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Stress test example homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
-Questions related to the usage of Apache Commons RNG Stress Test Example should be posted to the [user mailing list][ml].
+Questions related to the usage of Stress test example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?
 -----------------------------------
@@ -68,7 +68,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-examples-stress</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Stress Test Example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Stress test example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------

--- a/commons-rng-examples/examples-stress/README.md
+++ b/commons-rng-examples/examples-stress/README.md
@@ -98,7 +98,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-examples/examples-stress/README.md
+++ b/commons-rng-examples/examples-stress/README.md
@@ -55,7 +55,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-examples-stress/apidocs/) can be browsed.
 Questions related to the usage of Stress test example should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-examples/examples-stress/README.md
+++ b/commons-rng-examples/examples-stress/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -54,7 +54,7 @@ Application for calling external tools that perform stringent uniformity tests.
 Documentation
 -------------
 
-More information can be found on the [Stress test example homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Stress test example should be posted to the [user mailing list][ml].
 
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Stress test example? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-sampling/README.md
+++ b/commons-rng-sampling/README.md
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-sampling/README.md
+++ b/commons-rng-sampling/README.md
@@ -43,10 +43,10 @@
 Apache Commons RNG Sampling
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-sampling.svg?branch=master)](https://travis-ci.org/apache/commons-rng-sampling)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-sampling/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-sampling)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-sampling/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-sampling/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-sampling/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-sampling/1.2)
 
 The Apache Commons RNG Sampling module provides samplers
     for various distributions.
@@ -68,7 +68,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-sampling</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-sampling/README.md
+++ b/commons-rng-sampling/README.md
@@ -98,7 +98,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-sampling/README.md
+++ b/commons-rng-sampling/README.md
@@ -55,7 +55,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-sampling/apidocs/) can be browsed.
 Questions related to the usage of Apache Commons RNG Sampling should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-sampling/README.md
+++ b/commons-rng-sampling/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -54,7 +54,7 @@ The Apache Commons RNG Sampling module provides samplers
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Sampling homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG Sampling should be posted to the [user mailing list][ml].
 
@@ -93,12 +93,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Sampling? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-simple/README.md
+++ b/commons-rng-simple/README.md
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons RNG homepage](https://commons.apache.org/)
++ [Apache Commons homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-simple/README.md
+++ b/commons-rng-simple/README.md
@@ -34,7 +34,7 @@
  | 3) Example Properties                                                |
  |                                                                      |
  |  <properties>                                                        |
- |    <commons.componentid>math</commons.componentid>                   |
+ |    <commons.componentid>rng</commons.componentid>                    |
  |    <commons.release.version>1.2</commons.release.version>            |
  |  </properties>                                                       |
  |                                                                      |
@@ -53,7 +53,7 @@ Simple API for instantiating random numbers generators.
 Documentation
 -------------
 
-More information can be found on the [Apache Commons RNG Simple homepage](https://commons.apache.org/proper/commons-rng).
+More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
 The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
 Questions related to the usage of Apache Commons RNG Simple should be posted to the [user mailing list][ml].
 
@@ -92,12 +92,12 @@ See the `NOTICE.txt` file for required notices and attributions.
 
 Donations
 ---------
-You like Apache Commons RNG Simple? Then [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
+You like Apache Commons RNG? The [donate back to the ASF](https://www.apache.org/foundation/contributing.html) to support the development.
 
 Additional Resources
 --------------------
 
-+ [Apache Commons Homepage](https://commons.apache.org/)
++ [Apache Commons RNG homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`

--- a/commons-rng-simple/README.md
+++ b/commons-rng-simple/README.md
@@ -54,7 +54,7 @@ Documentation
 -------------
 
 More information can be found on the [Apache Commons RNG homepage](https://commons.apache.org/proper/commons-rng).
-The [Javadoc](https://commons.apache.org/proper/commons-rng/javadocs/api-release) can be browsed.
+The [Javadoc](https://commons.apache.org/proper/commons-rng/commons-rng-simple/apidocs/) can be browsed.
 Questions related to the usage of Apache Commons RNG Simple should be posted to the [user mailing list][ml].
 
 Where can I get the latest release?

--- a/commons-rng-simple/README.md
+++ b/commons-rng-simple/README.md
@@ -43,10 +43,10 @@
 Apache Commons RNG Simple
 ===================
 
-[![Build Status](https://travis-ci.org/apache/commons-rng-simple.svg?branch=master)](https://travis-ci.org/apache/commons-rng-simple)
-[![Coverage Status](https://coveralls.io/repos/apache/commons-rng-simple/badge.svg?branch=master)](https://coveralls.io/r/apache/commons-rng-simple)
+[![Build Status](https://travis-ci.org/apache/commons-rng.svg)](https://travis-ci.org/apache/commons-rng)
+[![Coverage Status](https://coveralls.io/repos/apache/commons-rng/badge.svg)](https://coveralls.io/r/apache/commons-rng)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-rng-simple/)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-rng-simple/1.2.svg)](https://javadoc.io/doc/org.apache.commons/commons-rng-simple/1.2)
 
 Simple API for instantiating random numbers generators.
 
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-rng-simple</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ```
 

--- a/commons-rng-simple/README.md
+++ b/commons-rng-simple/README.md
@@ -97,7 +97,7 @@ You like Apache Commons RNG? Then [donate back to the ASF](https://www.apache.or
 Additional Resources
 --------------------
 
-+ [Apache Commons homepage](https://commons.apache.org/)
++ [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/RNG)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
 + `#apache-commons` IRC channel on `irc.freenode.org`


### PR DESCRIPTION
All Javadoc links are now valid where appropriate.

Manual edits were made on the build plugin output to support the sub-modules.

