### PR TITLE
RNG-78: Added a ThreadLocalRandomSource.

### DIFF
--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/ThreadLocalPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/ThreadLocalPerformance.java
@@ -109,7 +109,7 @@ public class ThreadLocalPerformance {
     /**
      * Number of random values to generate.
      */
-    @Param({"0", "1"})
+    @Param({"0", "1", "10", "100"})
     private int numValues;
 
     /**
@@ -196,7 +196,7 @@ public class ThreadLocalPerformance {
      */
     @Benchmark
     @Threads(4)
-    public long threadLocalRNG(LocalSources localSources) {
+    public long threadLocalUniformRandomProvider(LocalSources localSources) {
         final UniformRandomProvider rng = localSources.getRNG();
         long result = 0;
         for (int i = 0; i < numValues; i++) {

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/ThreadLocalPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/ThreadLocalPerformance.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.examples.jmh;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.apache.commons.rng.simple.ThreadLocalRandomSource;
+
+/**
+ * Executes benchmark to compare the speed of generation of low frequency
+ * random numbers on multiple-threads.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-server", "-Xms128M", "-Xmx128M"})
+public class ThreadLocalPerformance {
+    /**
+     * The benchmark state (retrieve the various "RandomSource"s).
+     */
+    @State(Scope.Benchmark)
+    public static class Sources {
+        /**
+         * RNG providers.
+         */
+        @Param({"SPLIT_MIX_64",
+                "MWC_256" })
+        private String randomSourceName;
+
+        /** The random source. */
+        private RandomSource randomSource;
+
+        /**
+         * @return the random source
+         */
+        public RandomSource getRandomSource() {
+            return randomSource;
+        }
+
+        /** Instantiates the random source. */
+        @Setup
+        public void setup() {
+            randomSource = RandomSource.valueOf(randomSourceName);
+        }
+    }
+
+    /**
+     * Number of random values to generate.
+     */
+    @Param({"1", "10", "100"})
+    private int numValues;
+
+    /**
+     * @return the result
+     */
+    @Benchmark
+    @Threads(4)
+    public long threadLocalRandom() {
+        final ThreadLocalRandom rng = ThreadLocalRandom.current();
+        long result = 0;
+        for (int i = 0; i < numValues; i++) {
+            result = result ^ rng.nextLong();
+        }
+        return result;
+    }
+
+    /**
+     * @return the result
+     */
+    @Benchmark
+    @Threads(4)
+    public long threadLocalRandomWrapped() {
+        final ThreadLocalRandom rand = ThreadLocalRandom.current();
+        final UniformRandomProvider rng = new UniformRandomProvider() {
+            @Override
+            public void nextBytes(byte[] bytes) {}
+            @Override
+            public void nextBytes(byte[] bytes, int start, int len) {}
+            @Override
+            public int nextInt() { return rand.nextInt(); }
+            @Override
+            public int nextInt(int n) { return rand.nextInt(n); }
+            @Override
+            public long nextLong() { return rand.nextLong(); }
+            @Override
+            public long nextLong(long n) { return rand.nextLong(n); }
+            @Override
+            public boolean nextBoolean() { return rand.nextBoolean(); }
+            @Override
+            public float nextFloat() { return rand.nextFloat(); }
+            @Override
+            public double nextDouble() { return rand.nextDouble(); }
+        };
+        long result = 0;
+        for (int i = 0; i < numValues; i++) {
+            result = result ^ rng.nextLong();
+        }
+        return result;
+    }
+
+    /**
+     * @param sources Source of randomness.
+     * @return the result
+     */
+    @Benchmark
+    @Threads(4)
+    public long randomSourceCreate(Sources sources) {
+        final UniformRandomProvider rng = RandomSource.create(sources.getRandomSource());
+        long result = 0;
+        for (int i = 0; i < numValues; i++) {
+            result = result ^ rng.nextLong();
+        }
+        return result;
+    }
+
+    /**
+     * @param sources Source of randomness.
+     * @return the result
+     */
+    @Benchmark
+    @Threads(4)
+    public long threadLocalRandomSourceCurrent(Sources sources) {
+        final UniformRandomProvider rng = ThreadLocalRandomSource.current(sources.getRandomSource());
+        long result = 0;
+        for (int i = 0; i < numValues; i++) {
+            result = result ^ rng.nextLong();
+        }
+        return result;
+    }
+}

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.simple;
+
+import java.util.EnumMap;
+
+import org.apache.commons.rng.UniformRandomProvider;
+
+/**
+ * This class provides a thread-local {@link UniformRandomProvider}.
+ *
+ * <p>The {@link UniformRandomProvider} is created once-per-thread using the default
+ * construction method {@link RandomSource#create(RandomSource)}.
+ *
+ * <p>Example:</p>
+ * <pre><code>
+ * import org.apache.commons.rng.simple.RandomSource;
+ * import org.apache.commons.rng.simple.ThreadLocalRandomSource;
+ * import org.apache.commons.rng.sampling.distribution.PoissonSampler;
+ *
+ * // Access a thread-safe random number generator
+ * UniformRandomProvider rng = ThreadLocalRandomSource.current(RandomSource.SPLIT_MIX_64);
+ *
+ * // One-time Poisson sample
+ * double mean = 12.3;
+ * int counts = new PoissonSampler(rng, mean).sample();
+ * </code></pre>
+ *
+ * <p>Note if the {@link RandomSource} requires additional arguments then it is not
+ * supported. The same can be achieved using:</p>
+ *
+ * <pre><code>
+ * import org.apache.commons.rng.simple.RandomSource;
+ * import org.apache.commons.rng.sampling.distribution.PoissonSampler;
+ *
+ * // Provide a thread-safe random number generator with data arguments
+ * private static ThreadLocal&lt;UniformRandomProvider&gt; rng =
+ *     new ThreadLocal&lt;UniformRandomProvider&gt;() {
+ *         &#64;Override
+ *         protected UniformRandomProvider initialValue() {
+ *             return RandomSource.create(RandomSource.TWO_CMRES_SELECT, null, 3, 4);
+ *         }
+ *     };
+ *
+ * // One-time Poisson sample using a thread-safe random number generator
+ * double mean = 12.3;
+ * int counts = new PoissonSampler(rng.get(), mean).sample();
+ * </code></pre>
+ *
+ * @since 1.3
+ */
+public final class ThreadLocalRandomSource {
+    /**
+     * A map containing the {@link ThreadLocal} instance for each {@link RandomSource}.
+     *
+     * <p>This should only be modified to create new instances in a synchronized block.
+     */
+    private static EnumMap<RandomSource, ThreadLocal<UniformRandomProvider>> sources =
+        new EnumMap<RandomSource,
+                    ThreadLocal<UniformRandomProvider>>(RandomSource.class);
+
+    /** No public construction. */
+    private ThreadLocalRandomSource() {}
+
+    /**
+     * Extend the {@link ThreadLocal} to allow creation of the desired {@link RandomSource}.
+     */
+    private static class ThreadLocalRng extends ThreadLocal<UniformRandomProvider> {
+        /** The source. */
+        protected final RandomSource source;
+
+        /**
+         * Create a new instance.
+         *
+         * @param source the source
+         */
+        ThreadLocalRng(RandomSource source) {
+            this.source = source;
+        }
+
+        @Override
+        protected UniformRandomProvider initialValue() {
+            // Create with the default seed generation method
+            return RandomSource.create(source, null);
+        }
+    }
+
+    /**
+     * Returns the current thread's copy of the given {@code source}. If there is no
+     * value for the current thread, it is first initialized to the value returned
+     * by {@link RandomSource#create(RandomSource)}.
+     *
+     * <p>Note if the {@code source} requires additional arguments then it is not
+     * supported.
+     *
+     * @param source the source
+     * @return the current thread's value of the {@code source}.
+     * @throws IllegalArgumentException if the source is null or the source requires arguments
+     */
+    public static UniformRandomProvider current(RandomSource source) {
+        ThreadLocal<UniformRandomProvider> rng = sources.get(source);
+        // Implement double-checked locking:
+        // https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
+        if (rng == null) {
+            // Do the checks on the source here since it is an edge case
+            // and the EnumMap handles null (returning null).
+            if (source == null) {
+                throw new IllegalArgumentException("Random source is null");
+            }
+
+            synchronized (sources) {
+                rng = sources.get(source);
+                if (rng == null) {
+                    rng = new ThreadLocalRng(source);
+                    sources.put(source, rng);
+                }
+            }
+        }
+        return rng.get();
+    }
+}

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
@@ -81,7 +81,7 @@ public final class ThreadLocalRandomSource {
      */
     private static class ThreadLocalRng extends ThreadLocal<UniformRandomProvider> {
         /** The source. */
-        protected final RandomSource source;
+        private final RandomSource source;
 
         /**
          * Create a new instance.

--- a/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ThreadLocalRandomSourceTest.java
+++ b/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ThreadLocalRandomSourceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.simple;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+/**
+ * Tests for {@link ThreadLocalRandomSource}.
+ */
+public class ThreadLocalRandomSourceTest {
+    /**
+     * A set of all the RandomSource options that requires arguments. This should be
+     * ignored in certain tests since they are not supported.
+     */
+    private static EnumSet<RandomSource> toIgnore;
+
+    @BeforeClass
+    public static void createToIgnoreSet() {
+        toIgnore = EnumSet.of(RandomSource.TWO_CMRES_SELECT);
+    }
+
+    private static Object[] getData(Object ... data) {
+        return Arrays.copyOf(data, data.length);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testCurrentThrowsForNullRandomSource() {
+        ThreadLocalRandomSource.current(null);
+    }
+
+    //@Test(expected=IllegalArgumentException.class)
+    public void testCurrentThrowsForRandomSourceWithDataArguments() {
+        ThreadLocalRandomSource.current(RandomSource.TWO_CMRES_SELECT);
+    }
+
+    @Test
+    public void testCurrentForAllRandomSources() {
+        final RandomSource[] sources = RandomSource.values();
+        final UniformRandomProvider[] rngs = new UniformRandomProvider[sources.length];
+
+        for (int i = 0; i < sources.length; i++) {
+            if (toIgnore.contains(sources[i])) {
+                continue;
+            }
+            final UniformRandomProvider rng = getCurrent(sources[i]);
+            Assert.assertNotNull("Failed to create source: " + sources[i], rng);
+            rngs[i] = rng;
+        }
+        for (int i = 0; i < sources.length; i++) {
+            if (toIgnore.contains(sources[i])) {
+                continue;
+            }
+            final UniformRandomProvider rng = getCurrent(sources[i]);
+            Assert.assertSame("Failed to return same source: " + sources[i], rngs[i], rng);
+        }
+
+        // Build on a new thread. It should be different
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < sources.length; i++) {
+                    if (toIgnore.contains(sources[i])) {
+                        continue;
+                    }
+                    final UniformRandomProvider rng = getCurrent(sources[i]);
+                    Assert.assertNotSame("Failed to return different source: " + sources[i], rngs[i], rng);
+                }
+            }
+        }).start();
+    }
+
+    private static UniformRandomProvider getCurrent(RandomSource source) {
+        try {
+            return ThreadLocalRandomSource.current(source);
+        } catch (RuntimeException ex) {
+            throw new RuntimeException("Failed to get current: " + source, ex);
+        }
+    }
+}


### PR DESCRIPTION
Please review.

This add functionality to store a `ThreadLocal<UniformRandomProvider>` for each enum in `RandomSource`. This is seeded using the default seeding provided by `RandomSource.create(RandomSource)`.
