### PR TITLE
Jdk 11 build

### DIFF
--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/MersenneTwister.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source32/MersenneTwister.java
@@ -49,11 +49,12 @@ import org.apache.commons.rng.core.util.NumberFactory;
  * and Takuji Nishimura. Here is their original copyright:
  * </p>
  *
- * <table border="0" width="80%" cellpadding="10" style="background-color: #E0E0E0" summary="Mersenne Twister licence">
- * <tr><td>Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+ * <table style="background-color: #E0E0E0; width: 80%">
+ * <caption>Mersenne Twister licence</caption>
+ * <tr><td style="padding: 10px">Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
  *     All rights reserved.</td></tr>
  *
- * <tr><td>Redistribution and use in source and binary forms, with or without
+ * <tr><td style="padding: 10px">Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  * <ol>
@@ -67,7 +68,7 @@ import org.apache.commons.rng.core.util.NumberFactory;
  *       permission.</li>
  * </ol></td></tr>
  *
- * <tr><td><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * <tr><td style="padding: 10px"><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
  * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/MersenneTwister64.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/MersenneTwister64.java
@@ -35,11 +35,12 @@ import org.apache.commons.rng.core.util.NumberFactory;
  * Here is their original copyright:
  * </p>
  *
- * <table border="0" width="80%" cellpadding="10" style="background-color: #E0E0E0" summary="Mersenne Twister licence">
- * <tr><td>Copyright (C) 2004, Makoto Matsumoto and Takuji Nishimura,
+ * <table style="background-color: #E0E0E0; width: 80%">
+ * <caption>Mersenne Twister licence</caption>
+ * <tr><td style="padding: 10px">Copyright (C) 2004, Makoto Matsumoto and Takuji Nishimura,
  *     All rights reserved.</td></tr>
  *
- * <tr><td>Redistribution and use in source and binary forms, with or without
+ * <tr><td style="padding: 10px">Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  * <ol>
@@ -53,7 +54,7 @@ import org.apache.commons.rng.core.util.NumberFactory;
  *       permission.</li>
  * </ol></td></tr>
  *
- * <tr><td><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * <tr><td style="padding: 10px"><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
  * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/commons-rng-examples/examples-jpms/pom.xml
+++ b/commons-rng-examples/examples-jpms/pom.xml
@@ -47,12 +47,11 @@
 
   <build>
     <plugins>
-      <!--  Revert javadoc fix in parent -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>9</source>
+          <!-- Reset API links since these refer to java 1.6 and 1.7 -->
+          <links combine.self="override" />
         </configuration>
       </plugin>
     </plugins>
@@ -60,12 +59,11 @@
 
   <reporting>
     <plugins>
-      <!--  Revert javadoc fix in parent -->
+      <!--  Fix as per the <build> section -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>9</source>
+          <links combine.self="override" />
         </configuration>
       </plugin>
     </plugins>

--- a/commons-rng-examples/examples-jpms/pom.xml
+++ b/commons-rng-examples/examples-jpms/pom.xml
@@ -45,6 +45,32 @@
     <maven.compiler.release>9</maven.compiler.release>
   </properties>
 
+  <build>
+    <plugins>
+      <!--  Revert javadoc fix in parent -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <!--  Revert javadoc fix in parent -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <modules>
     <module>jpms-lib</module>
     <module>jpms-app</module>

--- a/pom.xml
+++ b/pom.xml
@@ -583,13 +583,13 @@
             </executions>
           </plugin>
           <!--  Fix required when building on JDK 11+ for javadoc <link> directing to packages in the
-            unnamed module. See properties commons.javadoc.java.link, commons.javadoc.javaee.link in 
-            commons-parent. -->
+            unnamed module: use the <source> tag. See properties commons.javadoc.java.link, 
+            commons.javadoc.javaee.link in commons-parent. -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <source>7</source>
+              <source>${maven.compiler.source}</source>
             </configuration>
           </plugin>
         </plugins>
@@ -616,13 +616,13 @@
             </reportSets>
           </plugin>
           <!--  Fix required when building on JDK 11+ for javadoc <link> directing to packages in the
-            unnamed module. See properties commons.javadoc.java.link, commons.javadoc.javaee.link in 
-            commons-parent. -->
+            unnamed module: use the <source> tag. See properties commons.javadoc.java.link, 
+            commons.javadoc.javaee.link in commons-parent. -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <source>7</source>
+              <source>${maven.compiler.source}</source>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,16 @@
               </execution>
             </executions>
           </plugin>
+          <!--  Fix required when building on JDK 11+ for javadoc <link> directing to packages in the
+            unnamed module. See properties commons.javadoc.java.link, commons.javadoc.javaee.link in 
+            commons-parent. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>7</source>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
       <reporting>
@@ -604,6 +614,16 @@
                 </reports>
               </reportSet>
             </reportSets>
+          </plugin>
+          <!--  Fix required when building on JDK 11+ for javadoc <link> directing to packages in the
+            unnamed module. See properties commons.javadoc.java.link, commons.javadoc.javaee.link in 
+            commons-parent. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <source>7</source>
+            </configuration>
           </plugin>
         </plugins>
       </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@
     <!-- Workaround to avoid duplicating config files. -->
     <rng.parent.dir>${basedir}</rng.parent.dir>
 
+    <!-- Version fix to support Java 11 site generation using parent-47 -->
+    <commons.spotbugs.version>3.1.11</commons.spotbugs.version>
+
     <!-- Jacoco version fix to support Java 8 & 11 using parent-47 -->
     <commons.jacoco.version>0.8.3</commons.jacoco.version>
     <commons.jacoco.classRatio>0.96</commons.jacoco.classRatio>


### PR DESCRIPTION
This fix allows:

`mvn clean package site`

to work on JDK 8 and 11.

`mvn clean package site -P commons-rng-examples`

does not work. Javadoc generation fails for the JPMS modules. The javadoc tool complains about links to a Javadoc API in the unamed modules:

```
The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/9/docs/api/ are in the unnamed module.
```

This javadoc issue when building using JDK 11 for a source earlier than 11 is found in a lot of web posts. The fix that works for a source earlier than 9 (i.e. using the `<source>7</source>` tag in the maven javadoc configuration) does not work when the source is 9 and has modules.

One simple workaround is to not use JDK 11 to build javadocs.


