### PR TITLE
RNG-91: Add a KempSmallMeanPoissonSampler

### DIFF
--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/DiscreteSamplersPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/DiscreteSamplersPerformance.java
@@ -22,6 +22,7 @@ import org.apache.commons.rng.examples.jmh.RandomSources;
 import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 import org.apache.commons.rng.sampling.distribution.DiscreteUniformSampler;
 import org.apache.commons.rng.sampling.distribution.GeometricSampler;
+import org.apache.commons.rng.sampling.distribution.KempSmallMeanPoissonSampler;
 import org.apache.commons.rng.sampling.distribution.LargeMeanPoissonSampler;
 import org.apache.commons.rng.sampling.distribution.RejectionInversionZipfSampler;
 import org.apache.commons.rng.sampling.distribution.SmallMeanPoissonSampler;
@@ -64,6 +65,7 @@ public class DiscreteSamplersPerformance {
         @Param({"DiscreteUniformSampler",
                 "RejectionInversionZipfSampler",
                 "SmallMeanPoissonSampler",
+                "KempSmallMeanPoissonSampler",
                 "LargeMeanPoissonSampler",
                 "GeometricSampler",
                 })
@@ -91,6 +93,8 @@ public class DiscreteSamplersPerformance {
                 sampler = new RejectionInversionZipfSampler(rng, 43, 2.1);
             } else if ("SmallMeanPoissonSampler".equals(samplerType)) {
                 sampler = new SmallMeanPoissonSampler(rng, 8.9);
+            } else if ("KempSmallMeanPoissonSampler".equals(samplerType)) {
+                sampler = new KempSmallMeanPoissonSampler(rng, 8.9);
             } else if ("LargeMeanPoissonSampler".equals(samplerType)) {
                 // Note: Use with a fractional part to the mean includes a small mean sample
                 sampler = new LargeMeanPoissonSampler(rng, 41.7);

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/PoissonSamplersPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/distribution/PoissonSamplersPerformance.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.examples.jmh.distribution;
+
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.examples.jmh.RandomSources;
+import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
+import org.apache.commons.rng.sampling.distribution.KempSmallMeanPoissonSampler;
+import org.apache.commons.rng.sampling.distribution.LargeMeanPoissonSampler;
+import org.apache.commons.rng.sampling.distribution.SmallMeanPoissonSampler;
+import org.apache.commons.rng.simple.RandomSource;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes benchmark to compare the speed of generation of random numbers
+ * from the various source providers for different types of {@link DiscreteSampler}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-server", "-Xms128M", "-Xmx128M"})
+public class PoissonSamplersPerformance {
+    /**
+     * The {@link DiscreteSampler} samplers to use for testing. Creates the sampler for each
+     * {@link RandomSource} in the default {@link RandomSources}.
+     */
+    @State(Scope.Benchmark)
+    public static class Sources extends RandomSources {
+        /**
+         * The sampler type.
+         */
+        @Param({"SmallMeanPoissonSampler",
+                "OriginalKempSmallMeanPoissonSampler",
+                "KempSmallMeanPoissonSampler",
+                "LargeMeanPoissonSampler",
+                })
+        private String samplerType;
+
+        /**
+         * The Poisson mean. This is set at a level where the small mean sampler is to be used
+         * in preference to the large mean sampler.
+         */
+        @Param({"0.25",
+                "0.5",
+                "1",
+                "2",
+                "4",
+                "8",
+                "16",
+                "32",
+                })
+        private double mean;
+
+        /** The sampler. */
+        private DiscreteSampler sampler;
+
+        /**
+         * @return the sampler.
+         */
+        public DiscreteSampler getSampler() {
+            return sampler;
+        }
+
+        /** Instantiates sampler. */
+        @Override
+        @Setup
+        public void setup() {
+            super.setup();
+            final UniformRandomProvider rng = getGenerator();
+            if ("SmallMeanPoissonSampler".equals(samplerType)) {
+                sampler = new SmallMeanPoissonSampler(rng, mean);
+            } else if ("OriginalKempSmallMeanPoissonSampler".equals(samplerType)) {
+                sampler = new OriginalKempSmallMeanPoissonSampler(rng, mean);
+            } else if ("KempSmallMeanPoissonSampler".equals(samplerType)) {
+                sampler = new KempSmallMeanPoissonSampler(rng, mean);
+            } else if ("LargeMeanPoissonSampler".equals(samplerType)) {
+                // Note this is not valid when mean < 1
+                sampler = new LargeMeanPoissonSampler(rng, mean);
+            }
+        }
+    }
+
+    /**
+     * Kemp sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson
+     * distribution</a>.
+     *
+     * <ul>
+     *  <li>
+     *   For small means, a Poisson process is simulated using uniform deviates, as
+     *   described in Kemp, A, W, (1981) Efficient Generation of Logarithmically Distributed
+     *   Pseudo-Random Variables. Journal of the Royal Statistical Society. Vol. 30, No. 3, pp. 249-253.
+     *  </li>
+     * </ul>
+     *
+     * <p>Note: This is the original algorithm by Kemp. It is included here for performance
+     * testing. The version in the RNG sampling module implements a hedge on the cumulative
+     * probability set at 50%. This saves computation in half of the samples.</p>
+     *
+     * @see <a href="https://www.jstor.org/stable/2346348">Kemp, A.W. (1981) JRSS Vol. 30, pp. 249-253</a>
+     */
+    static class OriginalKempSmallMeanPoissonSampler
+        implements DiscreteSampler {
+        /** Underlying source of randomness. */
+        private final UniformRandomProvider rng;
+        /**
+         * Pre-compute {@code Math.exp(-mean)}.
+         * Note: This is the probability of the Poisson sample {@code p(x=0)}.
+         */
+        private final double p0;
+        /**
+         * The mean of the Poisson sample.
+         */
+        private final double mean;
+
+        /**
+         * @param rng  Generator of uniformly distributed random numbers.
+         * @param mean Mean.
+         * @throws IllegalArgumentException if {@code mean <= 0} or {@code mean > 700}.
+         */
+        OriginalKempSmallMeanPoissonSampler(UniformRandomProvider rng,
+                                            double mean) {
+            if (mean <= 0) {
+                throw new IllegalArgumentException("mean is not strictly positive: " + mean);
+            }
+
+            p0 = Math.exp(-mean);
+            if (p0 == 0) {
+                throw new IllegalArgumentException("No probability for mean " + mean);
+            }
+            this.rng = rng;
+            this.mean = mean;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public int sample() {
+            // Note on the algorithm:
+            // - X is the unknown sample deviate (the output of the algorithm)
+            // - x is the current value from distribution
+            // - p is the probability of the current value x, p(X=x)
+            // - u is effectively the cumulative probability that the sample X
+            //   is equal or above the current value x, p(X>=x)
+            // So if p(X>=x) > p(X=x) the sample must be above x, otherwise it is x
+            double u = rng.nextDouble();
+            int x = 0;
+            double p = p0;
+            while (u > p) {
+                u -= p;
+                // Compute the next probability using a recurrence relation.
+                // p(x+1) = p(x) * mean / (x+1)
+                p *= mean / ++x;
+                // The algorithm listed in Kemp (1981) does not check that the rolling probability
+                // is positive. This check is added to ensure no errors when the limit of the summation
+                // 1 - sum(p(x)) is above 0 due to cumulative error in floating point arithmetic.
+                if (p == 0) {
+                    return x;
+                }
+            }
+            return x;
+        }
+    }
+
+    // Benchmarks methods below.
+
+    /**
+     * The value.
+     *
+     * <p>This must NOT be final!</p>
+     */
+    private int value;
+
+    /**
+     * Baseline for the JMH timing overhead for production of an {@code int} value.
+     *
+     * @return the {@code int} value
+     */
+    @Benchmark
+    public int baseline() {
+        return value;
+    }
+
+    /**
+     * Run the sampler.
+     *
+     * @param sources Source of randomness.
+     * @return the sample value
+     */
+    @Benchmark
+    public int sample(Sources sources) {
+        return sources.getSampler().sample();
+    }
+}

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSampler.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.rng.UniformRandomProvider;
+
+/**
+ * Sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson distribution</a>.
+ *
+ * <ul>
+ *  <li>
+ *   For small means, a Poisson process is simulated using uniform deviates, as
+ *   described in Kemp, A, W, (1981) Efficient Generation of Logarithmically Distributed
+ *   Pseudo-Random Variables. Journal of the Royal Statistical Society. Vol. 30, No. 3, pp. 249-253.
+ *  </li>
+ * </ul>
+ *
+ * <p>This sampler is suitable for {@code mean < 40}.
+ * For large means, {@link LargeMeanPoissonSampler} should be used instead.</p>
+ *
+ * <p>Note: The algorithm uses a recurrence relation to compute the Poisson probability and
+ * a rolling summation for the cumulative probability. When the mean is large the
+ * initial probability (Math.exp(-mean)) is zero and an exception is raised by the constructor.</p>
+ *
+ * <p>Sampling uses 1 call to {@link UniformRandomProvider#nextDouble()}.</p>
+ *
+ * @since 1.3
+ * @see <a href="https://www.jstor.org/stable/2346348">Kemp, A.W. (1981) JRSS Vol. 30, pp. 249-253</a>
+ */
+public class KempSmallMeanPoissonSampler
+    implements DiscreteSampler {
+    /** The value of p=0.5. */
+    private static final double ONE_HALF = 0.5;
+    /**
+     * The threshold that defines the cumulative probability for the long tail of the
+     * Poisson distribution. Above this threshold the recurrence relation that computes the
+     * next probability must check that the p-value is not zero.
+     */
+    private static final double LONG_TAIL_THRESHOLD = 0.999;
+
+    /** Underlying source of randomness. */
+    private final UniformRandomProvider rng;
+    /**
+     * Pre-compute {@code Math.exp(-mean)}.
+     * Note: This is the probability of the Poisson sample {@code p(x=0)}.
+     */
+    private final double p0;
+    /**
+     * The mean of the Poisson sample.
+     */
+    private final double mean;
+    /**
+     * Pre-compute the cumulative probability for all samples up to and including x.
+     * This is F(x) = sum of p(X<=x).
+     *
+     * <p>The value is computed at approximately 50% allowing the algorithm to choose to start
+     * at value (x+1) approximately half of the time.
+     */
+    private final double fx;
+    /**
+     * Store the value (x+1) corresponding to the next value after the cumulative probability is
+     * above 50%.
+     */
+    private final int x1;
+    /**
+     * Store the probability value p(x+1), allowing the algorithm to start from the point n+1.
+     */
+    private final double px1;
+
+    /**
+     * Create a new instance.
+     *
+     * <p>This is valid for means as large as approximately {@code 744}.</p>
+     *
+     * @param rng  Generator of uniformly distributed random numbers.
+     * @param mean Mean.
+     * @throws IllegalArgumentException if {@code mean <= 0} or {@code Math.exp(-mean) == 0}.
+     */
+    public KempSmallMeanPoissonSampler(UniformRandomProvider rng,
+                                       double mean) {
+        if (mean <= 0) {
+            throw new IllegalArgumentException("mean is not strictly positive: " + mean);
+        }
+
+        this.rng = rng;
+        p0 = Math.exp(-mean);
+        this.mean = mean;
+
+        // Pre-compute a hedge value for the cumulative probability at approximately 50%.
+        // This is only done when p0 is less than the long tail threshold.
+        // The result is that the rolling probability computation should never hit the
+        // long tail where p reaches zero.
+        if (p0 <= LONG_TAIL_THRESHOLD) {
+            // Check the edge case for no probability
+            if (p0 == 0) {
+                throw new IllegalArgumentException("No probability for mean " + mean);
+            }
+
+            double p = p0;
+            int x = 0;
+            // Sum is cumulative probability F(x) = sum p(X<=x)
+            double sum = p;
+            while (sum < ONE_HALF) {
+                // Compute the next probability using a recurrence relation.
+                // p(x+1) = p(x) * mean / (x+1)
+                p *= mean / ++x;
+                sum += p;
+            }
+            fx = sum;
+            x1 = x + 1;
+            px1 = p * mean / x1;
+        } else {
+            // Always start at zero.
+            // Note: If NaN is input as the mean this path is executed and the sample is always zero.
+            fx = 0;
+            x1 = 0;
+            px1 = p0;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int sample() {
+        // Note on the algorithm:
+        // - X is the unknown sample deviate (the output of the algorithm)
+        // - x is the current value from distribution
+        // - p is the probability of the current value x, p(X=x)
+        // - u is effectively the cumulative probability that the sample X
+        //   is equal or above the current value x, p(X>=x)
+        // So if p(X>=x) > p(X=x) the sample must be above x, otherwise it is x
+        final double u = rng.nextDouble();
+
+        if (u <= fx) {
+            // Sample from the lower half of the distribution starting at zero
+            return sampleBeforeLongTail(u, 0, p0);
+        }
+
+        // Sample from the upper half of the distribution starting at cumulative probability fx.
+        // This is reached when u > fx and sample X > x.
+
+        // If below the long tail threshold then omit the check on the asymptote of p -> zero
+        if (u <= LONG_TAIL_THRESHOLD) {
+            return sampleBeforeLongTail(u - fx, x1, px1);
+        }
+
+        return sampleWithinLongTail(u - fx, x1, px1);
+    }
+
+    /**
+     * Compute the sample assuming it is <strong>not</strong> in the long tail of the distribution.
+     *
+     * <p>This avoids a check on the next probability value assuming that the cumulative probability
+     * is at a level where the long tail of the Poisson distribution will not be reached.
+     *
+     * @param u the remaining cumulative probability (p(X>x))
+     * @param x the current sample value X
+     * @param p the current probability of the sample (p(X=x))
+     * @return the sample X
+     */
+    private int sampleBeforeLongTail(double u, int x, double p) {
+        while (u > p) {
+            // Update the remaining cumulative probability
+            u -= p;
+            // Compute the next probability using a recurrence relation.
+            // p(x+1) = p(x) * mean / (x+1)
+            p *= mean / ++x;
+            // The algorithm listed in Kemp (1981) does not check that the rolling probability
+            // is positive (non-zero). This is omitted here on the assumption that the cumulative
+            // probability will not be in the long tail where the probability asymptotes to zero.
+        }
+        return x;
+    }
+
+    /**
+     * Compute the sample assuming it is in the long tail of the distribution.
+     *
+     * <p>This requires a check on the next probability value which is expected to asymptote to zero.
+     *
+     * @param u the remaining cumulative probability
+     * @param x the current sample value X
+     * @param p the current probability of the sample (p(X=x))
+     * @return the sample X
+     */
+    private int sampleWithinLongTail(double u, int x, double p) {
+        while (u > p) {
+            // Update the remaining cumulative probability
+            u -= p;
+            // Compute the next probability using a recurrence relation.
+            // p(x+1) = p(x) * mean / (x+1)
+            p *= mean / ++x;
+            // The algorithm listed in Kemp (1981) does not check that the rolling probability
+            // is positive. This check is added to ensure no errors when the limit of the summation
+            // 1 - sum(p(x)) is above 0 due to cumulative error in floating point arithmetic when
+            // in the long tail of the distribution.
+            if (p == 0) {
+                return x;
+            }
+        }
+        return x;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "Kemp Small Mean Poisson deviate [" + rng.toString() + "]";
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
@@ -125,6 +125,9 @@ public class DiscreteSamplersList {
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
                 new SmallMeanPoissonSampler(RandomSource.create(RandomSource.KISS), meanPoisson));
+            add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
+                MathArrays.sequence(10, 0, 1),
+                new KempSmallMeanPoissonSampler(RandomSource.create(RandomSource.XO_SHI_RO_128_SS), meanPoisson));
             // Poisson (40 < mean < 80).
             final double largeMeanPoisson = 67.89;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, largeMeanPoisson, epsilonPoisson, maxIterationsPoisson),

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.sampling.distribution;
+
+import org.apache.commons.math3.distribution.PoissonDistribution;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for the {@link KempSmallMeanPoissonSampler}. The tests hit edge cases for the
+ * sampler and tests it functions at the supported upper bound on the mean.
+ */
+public class KempSmallMeanPoissonSamplerTest {
+    /**
+     * The upper limit on the mean.
+     *
+     * <p>p0 = Math.exp(-mean) => mean = -Math.log(p0).
+     */
+    private static final double SUPPORTED_UPPER_BOUND = -Math.log(Double.MIN_VALUE);
+
+    /** The rng for construction tests. */
+    private final UniformRandomProvider dummyRng = new FixedRNG(0);
+
+    /**
+     * Test the constructor with a bad mean.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorThrowsWithMeanLargerThanUpperBound() {
+        final double mean = SUPPORTED_UPPER_BOUND + 1;
+        @SuppressWarnings("unused")
+        KempSmallMeanPoissonSampler sampler = new KempSmallMeanPoissonSampler(dummyRng, mean);
+    }
+
+    /**
+     * Test the constructor with zero mean.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorThrowsWithZeroMean() {
+        final double mean = 0;
+        @SuppressWarnings("unused")
+        KempSmallMeanPoissonSampler sampler = new KempSmallMeanPoissonSampler(dummyRng, mean);
+    }
+
+    /**
+     * Test the constructor with a negative mean.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorThrowsWithNegativeMean() {
+        final double mean = -1;
+        @SuppressWarnings("unused")
+        KempSmallMeanPoissonSampler sampler = new KempSmallMeanPoissonSampler(dummyRng, mean);
+    }
+
+    /**
+     * Test the constructor with a NaN mean.
+     */
+    @Test
+    public void testConstructorWithNaNMean() {
+        final double mean = Double.NaN;
+        // The sampler is allowed but the sample will be zero no matter what the uniform
+        // random deviate returns.
+        Assert.assertEquals("Sample should be zero with cumulative probability 0",
+            0, new KempSmallMeanPoissonSampler(new FixedRNG(0), mean).sample());
+        Assert.assertEquals("Sample should be zero with cumulative probability 1",
+            0, new KempSmallMeanPoissonSampler(new FixedRNG(1), mean).sample());
+    }
+
+    /**
+     * Test the cumulative summation at the upper bound on the mean is close to zero.
+     */
+    @Test
+    public void testSummationAtUpperBound() {
+        final double mean = SUPPORTED_UPPER_BOUND;
+        double u = 1;
+        int x = 0;
+        double p = Math.exp(-mean);
+        while (u > p && p != 0) {
+            u -= p;
+            x = x + 1;
+            p = p * mean / x;
+        }
+        Assert.assertEquals("Summation is not zero", 0, u, 1e-3);
+    }
+
+    /**
+     * Test the sampler functions at a low mean. The mean is chosen so that the hedge at 50%
+     * cumulative probability is not used.
+     */
+    @Test
+    public void testSamplerAtLowMean() {
+        // Set the initial probability above the long tail threshold value (0.999)
+        final double p0 = 0.9995;
+        final double mean = -Math.log(p0);
+
+        // Test some ranges for the cumulative probability
+        final PoissonDistribution pd = new PoissonDistribution(null, mean,
+            PoissonDistribution.DEFAULT_EPSILON, PoissonDistribution.DEFAULT_MAX_ITERATIONS);
+
+        // Lower bound should be zero
+        testSample(mean, 0, 0, 0);
+
+        // When the mean is small the Poisson is highly skewed and the range of the achievable
+        // cumulative probability is small.
+        // Just test reasonable samples stating from 1.
+        double p = pd.cumulativeProbability(0);
+        for (int i = 1; i < 5; i++) {
+            final double lastP = p;
+            p = pd.cumulativeProbability(i);
+            testSample(mean, (p + lastP) / 2, i, i);
+        }
+    }
+
+    /**
+     * Test the sampler functions at the upper bound on the mean.
+     */
+    @Test
+    public void testSamplerAtUpperBounds() {
+        final double mean = SUPPORTED_UPPER_BOUND;
+
+        // Test some ranges for the cumulative probability
+        final PoissonDistribution pd = new PoissonDistribution(null, mean,
+            PoissonDistribution.DEFAULT_EPSILON, PoissonDistribution.DEFAULT_MAX_ITERATIONS);
+
+        // Lower bound should be zero
+        testSample(mean, 0, 0, 0);
+
+        // Upper bound should exceed 99.99% of the range
+        testSample(mean, 1, pd.inverseCumulativeProbability(0.9999), Integer.MAX_VALUE);
+
+        // A sample from within the cumulative probability should be within the expected range
+        for (int i = 1; i < 10; i++) {
+            final double p = i * 0.1;
+            final int lower = pd.inverseCumulativeProbability(p - 0.01);
+            final int upper = pd.inverseCumulativeProbability(p + 0.01);
+            testSample(mean, p, lower, upper);
+        }
+    }
+
+    /**
+     * Test a sample from the Poisson distribution at the given cumulative probability.
+     *
+     * @param mean the mean
+     * @param cumulativeProbability the cumulative probability
+     * @param lower the expected lower limit
+     * @param upper the expected upper limit
+     */
+    private static void testSample(double mean, double cumulativeProbability, int lower, int upper) {
+        final UniformRandomProvider rng = new FixedRNG(cumulativeProbability);
+        final KempSmallMeanPoissonSampler sampler = new KempSmallMeanPoissonSampler(rng, mean);
+        final int sample = sampler.sample();
+        Assert.assertTrue("Sampler is not above realistic lower limit: " + lower, sample >= lower);
+        Assert.assertTrue("Sampler is not below realistic upper limit: " + upper, sample <= upper);
+    }
+
+    /**
+     * A RNG returning a fixed value.
+     */
+    private static class FixedRNG implements UniformRandomProvider {
+        /** The value. */
+        private double value;
+
+        /**
+         * @param value the value
+         */
+        FixedRNG(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public double nextDouble() {
+            return value;
+        }
+
+        public long nextLong(long n) { return 0; }
+        public long nextLong() { return 0; }
+        public int nextInt(int n) { return 0; }
+        public int nextInt() { return 0; }
+        public float nextFloat() { return 0; }
+        public void nextBytes(byte[] bytes, int start, int len) {}
+        public void nextBytes(byte[] bytes) {}
+        public boolean nextBoolean() { return false; }
+    }
+}


### PR DESCRIPTION
The Kemp algorithm for sampling from a Poisson distribution.

This is faster that the current SmallMeanPoissonSampler when the RNG is slow. For a very fast generator the SmallMeanPoissonSampler outperforms this algorithm.

See the notes in the related Jira ticket.