### PR TITLE
RNG-77: Improve NumberFactory to/from byte arrays performance.

### DIFF
--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/util/NumberFactory.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/util/NumberFactory.java
@@ -206,14 +206,14 @@ public final class NumberFactory {
     private static void putLong(long v,
                                 byte[] buffer,
                                 int index) {
-        buffer[index    ] = (byte)( v         & LONG_LOWEST_BYTE_MASK);
+        buffer[index    ] = (byte) (v         & LONG_LOWEST_BYTE_MASK);
         buffer[index + 1] = (byte)((v >>>  8) & LONG_LOWEST_BYTE_MASK);
         buffer[index + 2] = (byte)((v >>> 16) & LONG_LOWEST_BYTE_MASK);
         buffer[index + 3] = (byte)((v >>> 24) & LONG_LOWEST_BYTE_MASK);
         buffer[index + 4] = (byte)((v >>> 32) & LONG_LOWEST_BYTE_MASK);
         buffer[index + 5] = (byte)((v >>> 40) & LONG_LOWEST_BYTE_MASK);
         buffer[index + 6] = (byte)((v >>> 48) & LONG_LOWEST_BYTE_MASK);
-        buffer[index + 7] = (byte)( v >>> 56                         );
+        buffer[index + 7] = (byte) (v >>> 56);
     }
 
     /**
@@ -318,10 +318,10 @@ public final class NumberFactory {
     private static void putInt(int v,
                                byte[] buffer,
                                int index) {
-        buffer[index    ] = (byte)( v         & INT_LOWEST_BYTE_MASK);
+        buffer[index    ] = (byte) (v         & INT_LOWEST_BYTE_MASK);
         buffer[index + 1] = (byte)((v >>>  8) & INT_LOWEST_BYTE_MASK);
         buffer[index + 2] = (byte)((v >>> 16) & INT_LOWEST_BYTE_MASK);
-        buffer[index + 3] = (byte)( v >>> 24                        );
+        buffer[index + 3] = (byte) (v >>> 24);
     }
     /**
      * Creates an {@code int} from 4 bytes.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -75,6 +75,9 @@ re-run tests that fail, and pass the build if they succeed
 within the allotted number of reruns (the test will be marked
 as 'flaky' in the report).
 ">
+      <action dev="aherbert" type="update" issue="RNG-77">
+        "NumberFactory": Improve performance of int and long array to/from byte array conversions.
+      </action>
       <action dev="aherbert" type="add" issue="101">
         New "MarsagliaTsangWangDiscreteSampler" that provides samples from a discrete
         distribution stored as a look-up table using a single random integer deviate. Computes


### PR DESCRIPTION
Changes the methods to read and write directly from the input / output
arrays avoiding creating an intermediate small array.

Additional tests were added to the `NumberFactoryTest` to ensure functionality was unchanged and the endian byte order of input/output arrays was maintained as documented in the method description.