### PR TITLE
RNG-103: Use KempSmallMeanPoissonSampler in LargeMeanPoissonSampler.

### DIFF
--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSampler.java
@@ -142,7 +142,7 @@ public class LargeMeanPoissonSampler
         final double lambdaFractional = mean - lambda;
         smallMeanPoissonSampler = (lambdaFractional < Double.MIN_VALUE) ?
             NO_SMALL_MEAN_POISSON_SAMPLER : // Not used.
-            new SmallMeanPoissonSampler(rng, lambdaFractional);
+            new KempSmallMeanPoissonSampler(rng, lambdaFractional);
     }
 
     /**
@@ -183,7 +183,7 @@ public class LargeMeanPoissonSampler
         // The algorithm requires a Poisson sample from the remaining lambda fraction.
         smallMeanPoissonSampler = (lambdaFractional < Double.MIN_VALUE) ?
             NO_SMALL_MEAN_POISSON_SAMPLER : // Not used.
-            new SmallMeanPoissonSampler(rng, lambdaFractional);
+            new KempSmallMeanPoissonSampler(rng, lambdaFractional);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The Kemp sampler has more stable performance at mean less than 1 than the SmallMeanPoissonSampler.