### PR TITLE
RNG-102: SharedStatedSampler interface

### DIFF
--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CollectionSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CollectionSampler.java
@@ -32,7 +32,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  *
  * @since 1.0
  */
-public class CollectionSampler<T> {
+public class CollectionSampler<T> implements SharedStateSampler<CollectionSampler<T>> {
     /** Collection to be sampled from. */
     private final List<T> items;
     /** RNG. */
@@ -57,6 +57,16 @@ public class CollectionSampler<T> {
     }
 
     /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private CollectionSampler(UniformRandomProvider rng,
+                              CollectionSampler<T> source) {
+        this.rng = rng;
+        items = source.items;
+    }
+
+    /**
      * Picks one of the items from the
      * {@link #CollectionSampler(UniformRandomProvider,Collection)
      * collection passed to the constructor}.
@@ -65,5 +75,11 @@ public class CollectionSampler<T> {
      */
     public T sample() {
         return items.get(rng.nextInt(items.size()));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CollectionSampler<T> withUniformRandomProvider(UniformRandomProvider rng) {
+        return new CollectionSampler<T>(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSampler.java
@@ -38,7 +38,8 @@ import org.apache.commons.rng.UniformRandomProvider;
  *
  * @since 1.1
  */
-public class DiscreteProbabilityCollectionSampler<T> {
+public class DiscreteProbabilityCollectionSampler<T>
+    implements SharedStateSampler<DiscreteProbabilityCollectionSampler<T>> {
     /** Collection to be sampled from. */
     private final List<T> items;
     /** RNG. */
@@ -125,6 +126,17 @@ public class DiscreteProbabilityCollectionSampler<T> {
     }
 
     /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private DiscreteProbabilityCollectionSampler(UniformRandomProvider rng,
+                                                 DiscreteProbabilityCollectionSampler<T> source) {
+        this.rng = rng;
+        this.items = source.items;
+        this.cumulativeProbabilities = source.cumulativeProbabilities;
+    }
+
+    /**
      * Picks one of the items from the collection passed to the constructor.
      *
      * @return a random sample.
@@ -146,6 +158,12 @@ public class DiscreteProbabilityCollectionSampler<T> {
         // object in case there is some floating point inequality problem
         // wrt the cumulative probabilities.
         return items.get(items.size() - 1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public DiscreteProbabilityCollectionSampler<T> withUniformRandomProvider(UniformRandomProvider rng) {
+        return new DiscreteProbabilityCollectionSampler<T>(rng, this);
     }
 
     /**

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/SharedStateSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/SharedStateSampler.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.sampling;
+
+import org.apache.commons.rng.UniformRandomProvider;
+
+/**
+ * Applies to samplers that can share state between instances. Samplers can be created with a
+ * new source of randomness that sample from the same state.
+ *
+ * @param <R> Type of the sampler.
+ * @since 1.3
+ */
+public interface SharedStateSampler<R> {
+    /**
+     * Create a new instance of the sampler with the same underlying state using the given
+     * uniform random provider as the source of randomness.
+     *
+     * @param rng Generator of uniformly distributed random numbers.
+     * @return the sampler
+     */
+    R withUniformRandomProvider(UniformRandomProvider rng);
+}

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/UnitSphereSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/UnitSphereSampler.java
@@ -34,7 +34,7 @@ import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSa
  *
  * @since 1.1
  */
-public class UnitSphereSampler {
+public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> {
     /** Sampler used for generating the individual components of the vectors. */
     private final NormalizedGaussianSampler sampler;
     /** Space dimension. */
@@ -54,6 +54,17 @@ public class UnitSphereSampler {
 
         this.dimension = dimension;
         sampler = new ZigguratNormalizedGaussianSampler(rng);
+    }
+
+    /**
+     * @param rng Generator for the individual components of the vectors.
+     * @param source Source to copy.
+     */
+    private UnitSphereSampler(UniformRandomProvider rng,
+                              UnitSphereSampler source) {
+        // The Gaussian sampler has no shared state so create a new instance
+        sampler = new ZigguratNormalizedGaussianSampler(rng);
+        dimension = source.dimension;
     }
 
     /**
@@ -86,5 +97,11 @@ public class UnitSphereSampler {
         }
 
         return v;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public UnitSphereSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new UnitSphereSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampling from an <a href="http://mathworld.wolfram.com/ExponentialDistribution.html">exponential distribution</a>.
@@ -27,7 +28,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class AhrensDieterExponentialSampler
     extends SamplerBase
-    implements ContinuousSampler {
+    implements ContinuousSampler, SharedStateSampler<AhrensDieterExponentialSampler> {
     /**
      * Table containing the constants
      * \( q_i = sum_{j=1}^i (\ln 2)^j / j! = \ln 2 + (\ln 2)^2 / 2 + ... + (\ln 2)^i / i! \)
@@ -78,6 +79,17 @@ public class AhrensDieterExponentialSampler
         this.mean = mean;
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private AhrensDieterExponentialSampler(UniformRandomProvider rng,
+                                           AhrensDieterExponentialSampler source) {
+        super(null);
+        this.rng = rng;
+        this.mean = source.mean;
+    }
+
     /** {@inheritDoc} */
     @Override
     public double sample() {
@@ -123,5 +135,11 @@ public class AhrensDieterExponentialSampler
     @Override
     public String toString() {
         return "Ahrens-Dieter Exponential deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AhrensDieterExponentialSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new AhrensDieterExponentialSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 import java.util.Arrays;
 
@@ -69,7 +70,8 @@ import java.util.Arrays;
  * @see <a href="https://ieeexplore.ieee.org/document/92917">Vose (1991) IEEE Transactions
  * on Software Engineering 17, 972-975.</a>
  */
-public class AliasMethodDiscreteSampler implements DiscreteSampler {
+public class AliasMethodDiscreteSampler
+    implements DiscreteSampler, SharedStateSampler<AliasMethodDiscreteSampler> {
     /**
      * The default alpha factor for zero-padding an input probability table. The default
      * value will pad the probabilities by to the next power-of-2.
@@ -182,8 +184,8 @@ public class AliasMethodDiscreteSampler implements DiscreteSampler {
          * @param alias Alias table.
          */
         SmallTableAliasMethodDiscreteSampler(final UniformRandomProvider rng,
-                                       final long[] probability,
-                                       final int[] alias) {
+                                             final long[] probability,
+                                             final int[] alias) {
             super(rng, probability, alias);
             // Assume the table size is a power of 2 and create the mask
             mask = alias.length - 1;
@@ -207,6 +209,12 @@ public class AliasMethodDiscreteSampler implements DiscreteSampler {
 
             // Choose between the two. Use a 53-bit long for the probability.
             return (longBits >>> 11) < probability[j] ? j : alias[j];
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public SmallTableAliasMethodDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            return new SmallTableAliasMethodDiscreteSampler(rng, probability, alias);
         }
     }
 
@@ -268,6 +276,12 @@ public class AliasMethodDiscreteSampler implements DiscreteSampler {
     @Override
     public String toString() {
         return "Alias method [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AliasMethodDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new AliasMethodDiscreteSampler(rng, probability, alias);
     }
 
     /**

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalizedGaussianSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalizedGaussianSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * <a href="https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform">
@@ -28,7 +29,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @since 1.1
  */
 public class BoxMullerNormalizedGaussianSampler
-    implements NormalizedGaussianSampler {
+    implements NormalizedGaussianSampler, SharedStateSampler<BoxMullerNormalizedGaussianSampler> {
     /** Next gaussian. */
     private double nextGaussian = Double.NaN;
     /** Underlying source of randomness. */
@@ -74,5 +75,11 @@ public class BoxMullerNormalizedGaussianSampler
     @Override
     public String toString() {
         return "Box-Muller normalized Gaussian deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public BoxMullerNormalizedGaussianSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new BoxMullerNormalizedGaussianSampler(rng);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ChengBetaSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ChengBetaSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Utility class implementing Cheng's algorithms for beta distribution sampling.
@@ -35,7 +36,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class ChengBetaSampler
     extends SamplerBase
-    implements ContinuousSampler {
+    implements ContinuousSampler, SharedStateSampler<ChengBetaSampler> {
     /** 1/2. */
     private static final double ONE_HALF = 1d / 2;
     /** 1/4. */
@@ -71,6 +72,18 @@ public class ChengBetaSampler
         betaShape = beta;
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private ChengBetaSampler(UniformRandomProvider rng,
+                             ChengBetaSampler source) {
+        super(null);
+        this.rng = rng;
+        alphaShape = source.alphaShape;
+        betaShape = source.betaShape;
+    }
+
     /** {@inheritDoc} */
     @Override
     public double sample() {
@@ -88,6 +101,12 @@ public class ChengBetaSampler
     @Override
     public String toString() {
         return "Cheng Beta deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ChengBetaSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new ChengBetaSampler(rng, this);
     }
 
     /**

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampling from a uniform distribution.
@@ -27,7 +28,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class ContinuousUniformSampler
     extends SamplerBase
-    implements ContinuousSampler {
+    implements ContinuousSampler, SharedStateSampler<ContinuousUniformSampler> {
     /** Lower bound. */
     private final double lo;
     /** Higher bound. */
@@ -60,5 +61,11 @@ public class ContinuousUniformSampler
     @Override
     public String toString() {
         return "Uniform deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ContinuousUniformSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new ContinuousUniformSampler(rng, lo, hi);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Compute a sample from a discrete probability distribution. The cumulative probability
@@ -40,7 +41,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @since 1.3
  */
 public class GuideTableDiscreteSampler
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<GuideTableDiscreteSampler> {
     /** The default value for {@code alpha}. */
     private static final double DEFAULT_ALPHA = 1.0;
     /** Underlying source of randomness. */
@@ -142,6 +143,17 @@ public class GuideTableDiscreteSampler
     }
 
     /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private GuideTableDiscreteSampler(UniformRandomProvider rng,
+                                      GuideTableDiscreteSampler source) {
+        this.rng = rng;
+        cumulativeProbabilities = source.cumulativeProbabilities;
+        guideTable = source.guideTable;
+    }
+
+    /**
      * Validate the parameters.
      *
      * @param probabilities The probabilities.
@@ -197,5 +209,11 @@ public class GuideTableDiscreteSampler
     @Override
     public String toString() {
         return "Guide table deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public GuideTableDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new GuideTableDiscreteSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Distribution sampler that uses the
@@ -57,7 +58,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class InverseTransformContinuousSampler
     extends SamplerBase
-    implements ContinuousSampler {
+    implements ContinuousSampler, SharedStateSampler<InverseTransformContinuousSampler> {
     /** Inverse cumulative probability function. */
     private final ContinuousInverseCumulativeProbabilityFunction function;
     /** Underlying source of randomness. */
@@ -84,5 +85,16 @@ public class InverseTransformContinuousSampler
     @Override
     public String toString() {
         return function.toString() + " (inverse method) [" + rng.toString() + "]";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: The new sampler will share the inverse cumulative probability function. This
+     * must be suitable for concurrent use to ensure thread safety.</p>
+     */
+    @Override
+    public InverseTransformContinuousSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new InverseTransformContinuousSampler(rng, function);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Distribution sampler that uses the
@@ -57,7 +58,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class InverseTransformDiscreteSampler
     extends SamplerBase
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<InverseTransformDiscreteSampler> {
     /** Inverse cumulative probability function. */
     private final DiscreteInverseCumulativeProbabilityFunction function;
     /** Underlying source of randomness. */
@@ -84,5 +85,16 @@ public class InverseTransformDiscreteSampler
     @Override
     public String toString() {
         return function.toString() + " (inverse method) [" + rng.toString() + "]";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: The new sampler will share the inverse cumulative probability function. This
+     * must be suitable for concurrent use to ensure thread safety.</p>
+     */
+    @Override
+    public InverseTransformDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new InverseTransformDiscreteSampler(rng, function);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampling from a <a href="https://en.wikipedia.org/wiki/Pareto_distribution">Pareto distribution</a>.
@@ -27,7 +28,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class InverseTransformParetoSampler
     extends SamplerBase
-    implements ContinuousSampler {
+    implements ContinuousSampler, SharedStateSampler<InverseTransformParetoSampler> {
     /** Scale. */
     private final double scale;
     /** 1 / Shape. */
@@ -56,6 +57,18 @@ public class InverseTransformParetoSampler
         this.oneOverShape = 1 / shape;
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private InverseTransformParetoSampler(UniformRandomProvider rng,
+                                          InverseTransformParetoSampler source) {
+        super(null);
+        this.rng = rng;
+        scale = source.scale;
+        oneOverShape = source.oneOverShape;
+    }
+
     /** {@inheritDoc} */
     @Override
     public double sample() {
@@ -66,5 +79,11 @@ public class InverseTransformParetoSampler
     @Override
     public String toString() {
         return "[Inverse method for Pareto distribution " + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public InverseTransformParetoSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new InverseTransformParetoSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson
@@ -46,7 +47,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * 249-253</a>
  */
 public class KempSmallMeanPoissonSampler
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<KempSmallMeanPoissonSampler> {
     /** Underlying source of randomness. */
     private final UniformRandomProvider rng;
     /**
@@ -81,6 +82,17 @@ public class KempSmallMeanPoissonSampler
         }
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private KempSmallMeanPoissonSampler(UniformRandomProvider rng,
+                                        KempSmallMeanPoissonSampler source) {
+        this.rng = rng;
+        p0 = source.p0;
+        mean = source.mean;
+    }
+
     /** {@inheritDoc} */
     @Override
     public int sample() {
@@ -113,5 +125,11 @@ public class KempSmallMeanPoissonSampler
     @Override
     public String toString() {
         return "Kemp Small Mean Poisson deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public KempSmallMeanPoissonSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new KempSmallMeanPoissonSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalizedGaussianSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalizedGaussianSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * <a href="https://en.wikipedia.org/wiki/Marsaglia_polar_method">
@@ -30,7 +31,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @since 1.1
  */
 public class MarsagliaNormalizedGaussianSampler
-    implements NormalizedGaussianSampler {
+    implements NormalizedGaussianSampler, SharedStateSampler<MarsagliaNormalizedGaussianSampler> {
     /** Next gaussian. */
     private double nextGaussian = Double.NaN;
     /** Underlying source of randomness. */
@@ -83,5 +84,11 @@ public class MarsagliaNormalizedGaussianSampler
     @Override
     public String toString() {
         return "Box-Muller (with rejection) normalized Gaussian deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MarsagliaNormalizedGaussianSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new MarsagliaNormalizedGaussianSampler(rng);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/MarsagliaTsangWangDiscreteSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/MarsagliaTsangWangDiscreteSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampler for a discrete distribution using an optimised look-up table.
@@ -49,7 +50,8 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @see <a href="http://dx.doi.org/10.18637/jss.v011.i03">Margsglia, et al (2004) JSS Vol.
  * 11, Issue 3</a>
  */
-public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampler {
+public abstract class MarsagliaTsangWangDiscreteSampler
+    implements DiscreteSampler, SharedStateSampler<MarsagliaTsangWangDiscreteSampler> {
     /** The value 2<sup>8</sup> as an {@code int}. */
     private static final int INT_8 = 1 << 8;
     /** The value 2<sup>16</sup> as an {@code int}. */
@@ -193,6 +195,24 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
         }
 
         /**
+         * @param rng Generator of uniformly distributed random numbers.
+         * @param source Source to copy.
+         */
+        private MarsagliaTsangWangBase64Int8DiscreteSampler(UniformRandomProvider rng,
+                MarsagliaTsangWangBase64Int8DiscreteSampler source) {
+            super(rng, source);
+            t1 = source.t1;
+            t2 = source.t2;
+            t3 = source.t3;
+            t4 = source.t4;
+            table1 = source.table1;
+            table2 = source.table2;
+            table3 = source.table3;
+            table4 = source.table4;
+            table5 = source.table5;
+        }
+
+        /**
          * Fill the table with the value.
          *
          * @param table Table.
@@ -206,7 +226,6 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             }
         }
 
-        /** {@inheritDoc} */
         @Override
         public int sample() {
             final int j = rng.nextInt() >>> 2;
@@ -226,6 +245,11 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             // is >=2^30. If this is not true then the final table table5 will be smaller by the
             // difference. So the tables *must* be constructed correctly.
             return table5[j - t4] & MASK;
+        }
+
+        @Override
+        public MarsagliaTsangWangDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            return new MarsagliaTsangWangBase64Int8DiscreteSampler(rng, this);
         }
     }
 
@@ -311,6 +335,24 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
         }
 
         /**
+         * @param rng Generator of uniformly distributed random numbers.
+         * @param source Source to copy.
+         */
+        private MarsagliaTsangWangBase64Int16DiscreteSampler(UniformRandomProvider rng,
+                MarsagliaTsangWangBase64Int16DiscreteSampler source) {
+            super(rng, source);
+            t1 = source.t1;
+            t2 = source.t2;
+            t3 = source.t3;
+            t4 = source.t4;
+            table1 = source.table1;
+            table2 = source.table2;
+            table3 = source.table3;
+            table4 = source.table4;
+            table5 = source.table5;
+        }
+
+        /**
          * Fill the table with the value.
          *
          * @param table Table.
@@ -324,7 +366,6 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             }
         }
 
-        /** {@inheritDoc} */
         @Override
         public int sample() {
             final int j = rng.nextInt() >>> 2;
@@ -345,6 +386,11 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             // difference. So the tables *must* be constructed correctly.
             return table5[j - t4] & MASK;
         }
+
+        @Override
+        public MarsagliaTsangWangDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            return new MarsagliaTsangWangBase64Int16DiscreteSampler(rng, this);
+        }
     }
 
     /**
@@ -353,7 +399,6 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
      */
     private static class MarsagliaTsangWangBase64Int32DiscreteSampler
         extends MarsagliaTsangWangDiscreteSampler {
-
         /** Limit for look-up table 1. */
         private final int t1;
         /** Limit for look-up table 2. */
@@ -426,6 +471,24 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
         }
 
         /**
+         * @param rng Generator of uniformly distributed random numbers.
+         * @param source Source to copy.
+         */
+        private MarsagliaTsangWangBase64Int32DiscreteSampler(UniformRandomProvider rng,
+                MarsagliaTsangWangBase64Int32DiscreteSampler source) {
+            super(rng, source);
+            t1 = source.t1;
+            t2 = source.t2;
+            t3 = source.t3;
+            t4 = source.t4;
+            table1 = source.table1;
+            table2 = source.table2;
+            table3 = source.table3;
+            table4 = source.table4;
+            table5 = source.table5;
+        }
+
+        /**
          * Fill the table with the value.
          *
          * @param table Table.
@@ -439,7 +502,6 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             }
         }
 
-        /** {@inheritDoc} */
         @Override
         public int sample() {
             final int j = rng.nextInt() >>> 2;
@@ -459,6 +521,11 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             // is >=2^30. If this is not true then the final table table5 will be smaller by the
             // difference. So the tables *must* be constructed correctly.
             return table5[j - t4];
+        }
+
+        @Override
+        public MarsagliaTsangWangDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            return new MarsagliaTsangWangBase64Int32DiscreteSampler(rng, this);
         }
     }
 
@@ -484,10 +551,15 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             return result;
         }
 
-        /** {@inheritDoc} */
         @Override
         public String toString() {
             return BINOMIAL_NAME + " deviate";
+        }
+
+        @Override
+        public MarsagliaTsangWangDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            // No shared state
+            return this;
         }
     }
 
@@ -522,10 +594,15 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
             return trials - sampler.sample();
         }
 
-        /** {@inheritDoc} */
         @Override
         public String toString() {
             return sampler.toString();
+        }
+
+        @Override
+        public MarsagliaTsangWangDiscreteSampler withUniformRandomProvider(UniformRandomProvider rng) {
+            return new MarsagliaTsangWangInversionBinomialSampler(this.trials,
+                this.sampler.withUniformRandomProvider(rng));
         }
     }
 
@@ -537,6 +614,16 @@ public abstract class MarsagliaTsangWangDiscreteSampler implements DiscreteSampl
                                       String distributionName) {
         this.rng = rng;
         this.distributionName = distributionName;
+    }
+
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    MarsagliaTsangWangDiscreteSampler(UniformRandomProvider rng,
+                                      MarsagliaTsangWangDiscreteSampler source) {
+        this.rng = rng;
+        this.distributionName = source.distributionName;
     }
 
     /** {@inheritDoc} */

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/PoissonSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson distribution</a>.
@@ -51,7 +52,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class PoissonSampler
     extends SamplerBase
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<PoissonSampler> {
 
     /**
      * Value for switching sampling algorithm.
@@ -79,6 +80,23 @@ public class PoissonSampler
             new LargeMeanPoissonSampler(rng, mean);
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private PoissonSampler(UniformRandomProvider rng,
+            PoissonSampler source) {
+        super(null);
+
+        if (source.poissonSamplerDelegate instanceof SmallMeanPoissonSampler) {
+            poissonSamplerDelegate =
+                ((SmallMeanPoissonSampler)source.poissonSamplerDelegate).withUniformRandomProvider(rng);
+        } else {
+            poissonSamplerDelegate =
+                ((LargeMeanPoissonSampler)source.poissonSamplerDelegate).withUniformRandomProvider(rng);
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public int sample() {
@@ -89,5 +107,11 @@ public class PoissonSampler
     @Override
     public String toString() {
         return poissonSamplerDelegate.toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PoissonSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new PoissonSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSampler.java
@@ -18,6 +18,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Implementation of the <a href="https://en.wikipedia.org/wiki/Zipf's_law">Zipf distribution</a>.
@@ -28,7 +29,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  */
 public class RejectionInversionZipfSampler
     extends SamplerBase
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<RejectionInversionZipfSampler> {
     /** Threshold below which Taylor series will be used. */
     private static final double TAYLOR_THRESHOLD = 1e-8;
     /** 1/2. */
@@ -74,6 +75,21 @@ public class RejectionInversionZipfSampler
         this.hIntegralX1 = hIntegral(1.5) - 1;
         this.hIntegralNumberOfElements = hIntegral(numberOfElements + F_1_2);
         this.s = 2 - hIntegralInverse(hIntegral(2.5) - h(2));
+    }
+
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private RejectionInversionZipfSampler(UniformRandomProvider rng,
+                                          RejectionInversionZipfSampler source) {
+        super(null);
+        this.rng = rng;
+        this.numberOfElements = source.numberOfElements;
+        this.exponent = source.exponent;
+        this.hIntegralX1 = source.hIntegralX1;
+        this.hIntegralNumberOfElements = source.hIntegralNumberOfElements;
+        this.s = source.s;
     }
 
     /**
@@ -175,6 +191,12 @@ public class RejectionInversionZipfSampler
     @Override
     public String toString() {
         return "Rejection inversion Zipf deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RejectionInversionZipfSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new RejectionInversionZipfSampler(rng, this);
     }
 
     /**

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSampler.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * Sampler for the <a href="http://mathworld.wolfram.com/PoissonDistribution.html">Poisson distribution</a>.
@@ -42,7 +43,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @since 1.1
  */
 public class SmallMeanPoissonSampler
-    implements DiscreteSampler {
+    implements DiscreteSampler, SharedStateSampler<SmallMeanPoissonSampler> {
     /**
      * Pre-compute {@code Math.exp(-mean)}.
      * Note: This is the probability of the Poisson sample {@code P(n=0)}.
@@ -74,6 +75,17 @@ public class SmallMeanPoissonSampler
         }
     }
 
+    /**
+     * @param rng Generator of uniformly distributed random numbers.
+     * @param source Source to copy.
+     */
+    private SmallMeanPoissonSampler(UniformRandomProvider rng,
+                                    SmallMeanPoissonSampler source) {
+        this.rng = rng;
+        p0 = source.p0;
+        limit = source.limit;
+    }
+
     /** {@inheritDoc} */
     @Override
     public int sample() {
@@ -95,5 +107,11 @@ public class SmallMeanPoissonSampler
     @Override
     public String toString() {
         return "Small Mean Poisson deviate [" + rng.toString() + "]";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SmallMeanPoissonSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new SmallMeanPoissonSampler(rng, this);
     }
 }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSampler.java
@@ -18,6 +18,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 
 /**
  * <a href="https://en.wikipedia.org/wiki/Ziggurat_algorithm">
@@ -38,7 +39,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * @since 1.1
  */
 public class ZigguratNormalizedGaussianSampler
-    implements NormalizedGaussianSampler {
+    implements NormalizedGaussianSampler, SharedStateSampler<ZigguratNormalizedGaussianSampler> {
     /** Start of tail. */
     private static final double R = 3.442619855899;
     /** Inverse of R. */
@@ -159,5 +160,11 @@ public class ZigguratNormalizedGaussianSampler
      */
     private static double gauss(double x) {
         return Math.exp(-0.5 * x * x);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ZigguratNormalizedGaussianSampler withUniformRandomProvider(UniformRandomProvider rng) {
+        return new ZigguratNormalizedGaussianSampler(rng);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CollectionSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CollectionSamplerTest.java
@@ -17,10 +17,12 @@
 package org.apache.commons.rng.sampling;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-
+import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.simple.RandomSource;
 
 /**
@@ -52,5 +54,31 @@ public class CollectionSamplerTest {
         // Must fail for empty collection.
         new CollectionSampler<String>(RandomSource.create(RandomSource.MT),
                                       new ArrayList<String>());
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final List<String> list = Arrays.asList("Apache", "Commons", "RNG");
+        final CollectionSampler<String> sampler1 =
+            new CollectionSampler<String>(rng1, list);
+        final CollectionSampler<String> sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(
+            new RandomAssert.Sampler<String>() {
+                @Override
+                public String sample() {
+                    return sampler1.sample();
+                }
+            },
+            new RandomAssert.Sampler<String>() {
+                @Override
+                public String sample() {
+                    return sampler2.sample();
+                }
+            });
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CombinationSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CombinationSamplerTest.java
@@ -113,6 +113,33 @@ public class CombinationSamplerTest {
         new CombinationSampler(rng, n, k);
     }
 
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final int n = 17;
+        final int k = 3;
+        final CombinationSampler sampler1 =
+            new CombinationSampler(rng1, n, k);
+        final CombinationSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(
+            new RandomAssert.Sampler<int[]>() {
+                @Override
+                public int[] sample() {
+                    return sampler1.sample();
+                }
+            },
+            new RandomAssert.Sampler<int[]>() {
+                @Override
+                public int[] sample() {
+                    return sampler2.sample();
+                }
+            });
+    }
+
     //// Support methods.
 
     /**

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSamplerTest.java
@@ -152,4 +152,32 @@ public class DiscreteProbabilityCollectionSamplerTest {
         // Test the two samples are different items
         Assert.assertNotSame("Item1 and 2 should be different", item1, item2);
     }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final List<Double> items = Arrays.asList(new Double[] {1d, 2d, 3d, 4d});
+        final DiscreteProbabilityCollectionSampler<Double> sampler1 =
+            new DiscreteProbabilityCollectionSampler<Double>(rng1,
+                                                             items,
+                                                             new double[] {0.1, 0.2, 0.3, 04});
+        final DiscreteProbabilityCollectionSampler<Double> sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(
+            new RandomAssert.Sampler<Double>() {
+                @Override
+                public Double sample() {
+                    return sampler1.sample();
+                }
+            },
+            new RandomAssert.Sampler<Double>() {
+                @Override
+                public Double sample() {
+                    return sampler2.sample();
+                }
+            });
+    }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/PermutationSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/PermutationSamplerTest.java
@@ -186,6 +186,33 @@ public class PermutationSamplerTest {
         Assert.assertTrue(ok);
     }
 
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final int n = 17;
+        final int k = 13;
+        final PermutationSampler sampler1 =
+            new PermutationSampler(rng1, n, k);
+        final PermutationSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(
+            new RandomAssert.Sampler<int[]>() {
+                @Override
+                public int[] sample() {
+                    return sampler1.sample();
+                }
+            },
+            new RandomAssert.Sampler<int[]>() {
+                @Override
+                public int[] sample() {
+                    return sampler2.sample();
+                }
+            });
+    }
+
     //// Support methods.
 
     private void runSampleChiSquareTest(int n,

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/RandomAssert.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/RandomAssert.java
@@ -97,7 +97,8 @@ public final class RandomAssert {
             final T value1 = sampler1.sample();
             final T value2 = sampler2.sample();
             if (isArray(value1) && isArray(value2)) {
-                Assert.assertArrayEquals((Object[]) value1, (Object[]) value2);
+                // JUnit assertArrayEquals will handle nested primitive arrays
+                Assert.assertArrayEquals(new Object[] {value1}, new Object[] {value2});
             } else {
                 Assert.assertEquals(value1, value2);
             }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/RandomAssert.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/RandomAssert.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.sampling;
+
+import org.junit.Assert;
+
+import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
+import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
+
+/**
+ * Utility class for testing random samplers.
+ */
+public final class RandomAssert {
+    /** Number of samples to generate to test for equal sequences. */
+    private static final int SAMPLES = 10;
+
+    /**
+     * Defines a generic sampler.
+     *
+     * @param <T> the type of the sample
+     */
+    public interface Sampler<T> {
+        /**
+         * Creates a sample.
+         *
+         * @return a sample.
+         */
+        T sample();
+    }
+
+    /**
+     * Class contains only static methods.
+     */
+    private RandomAssert() {}
+
+    /**
+     * Exercise the {@link ContinuousSampler} interface, and
+     * ensure that the two samplers produce the same sequence.
+     *
+     * @param sampler1 First sampler.
+     * @param sampler2 Second sampler.
+     */
+    public static void assertProduceSameSequence(ContinuousSampler sampler1,
+                                                 ContinuousSampler sampler2) {
+        for (int i = 0; i < SAMPLES; i++) {
+            Assert.assertEquals(sampler1.sample(), sampler2.sample(), 0.0);
+        }
+    }
+
+    /**
+     * Exercise the {@link DiscreteSampler} interface, and
+     * ensure that the two samplers produce the same sequence.
+     *
+     * @param sampler1 First sampler.
+     * @param sampler2 Second sampler.
+     */
+    public static void assertProduceSameSequence(DiscreteSampler sampler1,
+                                                 DiscreteSampler sampler2) {
+        for (int i = 0; i < SAMPLES; i++) {
+            Assert.assertEquals(sampler1.sample(), sampler2.sample());
+        }
+    }
+
+    /**
+     * Exercise the {@link Sampler} interface, and
+     * ensure that the two samplers produce the same sequence.
+     *
+     * <p>Arrays are tested using {@link Assert#assertArrayEquals(Object[], Object[])}
+     * which handles primitive arrays using exact equality and objects using
+     * {@link Object#equals(Object)}. Otherwise {@link Assert#assertEquals(Object, Object)}
+     * is used which makes use of {@link Object#equals(Object)}.</p>
+     *
+     * <p>This should be used to test samplers of any type by wrapping the sample method
+     * to an anonymous {@link Sampler} class.</p>
+     *
+     * @param sampler1 First sampler.
+     * @param sampler2 Second sampler.
+     */
+    public static <T> void assertProduceSameSequence(Sampler<T> sampler1,
+                                                     Sampler<T> sampler2) {
+        for (int i = 0; i < SAMPLES; i++) {
+            final T value1 = sampler1.sample();
+            final T value2 = sampler2.sample();
+            if (isArray(value1) && isArray(value2)) {
+                Assert.assertArrayEquals((Object[]) value1, (Object[]) value2);
+            } else {
+                Assert.assertEquals(value1, value2);
+            }
+        }
+    }
+
+    /**
+     * Checks if the object is an array.
+     *
+     * @param object Object.
+     * @return true if an array
+     */
+    private static boolean isArray(Object object) {
+        return object != null && object.getClass().isArray();
+    }
+}

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
@@ -115,6 +115,32 @@ public class UnitSphereSamplerTest {
     }
 
     /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final int n = 3;
+        final UnitSphereSampler sampler1 =
+            new UnitSphereSampler(n, rng1);
+        final UnitSphereSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(
+            new RandomAssert.Sampler<double[]>() {
+                @Override
+                public double[] sample() {
+                    return sampler1.nextVector();
+                }
+            },
+            new RandomAssert.Sampler<double[]>() {
+                @Override
+                public double[] sample() {
+                    return sampler2.nextVector();
+                }
+            });
+    }
+
+    /**
      * @return the length (L2-norm) of given vector.
      */
     private static double length(double[] vector) {

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -35,5 +37,19 @@ public class AhrensDieterExponentialSamplerTest {
         @SuppressWarnings("unused")
         final AhrensDieterExponentialSampler sampler =
             new AhrensDieterExponentialSampler(rng, mean);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double mean = 1.23;
+        final AhrensDieterExponentialSampler sampler1 =
+            new AhrensDieterExponentialSampler(rng1, mean);
+        final AhrensDieterExponentialSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -50,5 +52,36 @@ public class AhrensDieterMarsagliaTsangGammaSamplerTest {
         @SuppressWarnings("unused")
         final AhrensDieterMarsagliaTsangGammaSampler sampler =
             new AhrensDieterMarsagliaTsangGammaSampler(rng, alpha, theta);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSamplerWithAlphaBelowOne() {
+        testSharedStateSampler(0.5, 3.456);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSamplerWithAlphaAboveOne() {
+        testSharedStateSampler(3.5, 3.456);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     *
+     * @param alpha Alpha.
+     * @param theta Theta.
+     */
+    private static void testSharedStateSampler(double alpha, double theta) {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final AhrensDieterMarsagliaTsangGammaSampler sampler1 =
+            new AhrensDieterMarsagliaTsangGammaSampler(rng1, alpha, theta);
+        final AhrensDieterMarsagliaTsangGammaSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSamplerTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.stat.inference.ChiSquareTest;
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
@@ -247,5 +248,36 @@ public class AliasMethodDiscreteSamplerTest {
         final ChiSquareTest chiSquareTest = new ChiSquareTest();
         // Pass if we cannot reject null hypothesis that the distributions are the same.
         Assert.assertFalse(chiSquareTest.chiSquareTest(expected, observed, 0.001));
+    }
+
+    /**
+     * Test the SharedStateSampler implementation for the specialised power-of-2 table size.
+     */
+    @Test
+    public void testSharedStateSamplerWithPowerOf2TableSize() {
+        testSharedStateSampler(new double[] {0.1, 0.2, 0.3, 0.4});
+    }
+
+    /**
+     * Test the SharedStateSampler implementation for the generic non power-of-2 table size.
+     */
+    @Test
+    public void testSharedStateSamplerWithNonPowerOf2TableSize() {
+        testSharedStateSampler(new double[] {0.1, 0.2, 0.3});
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     *
+     * @param probabilities The probabilities
+     */
+    private static void testSharedStateSampler(double[] probabilities) {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        // Use negative alpha to disable padding
+        final AliasMethodDiscreteSampler sampler1 =
+            AliasMethodDiscreteSampler.create(rng1, probabilities, -1);
+        final AliasMethodDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalisedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalisedGaussianSamplerTest.java
@@ -19,36 +19,12 @@ package org.apache.commons.rng.sampling.distribution;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Test for the {@link ContinuousUniformSampler}.
+ * Test for the {@link BoxMullerNormalizedGaussianSampler}.
  */
-public class ContinuousUniformSamplerTest {
-    /**
-     * Test that the sampler algorithm does not require high to be above low.
-     */
-    @Test
-    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
-        final double low = 3.18;
-        final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
-        testSampleInRange(rng, low, high);
-        testSampleInRange(rng, high, low);
-    }
-
-    private static void testSampleInRange(UniformRandomProvider rng,
-                                          double low, double high) {
-        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
-        final double min = Math.min(low,  high);
-        final double max = Math.max(low,  high);
-        for (int i = 0; i < 10; i++) {
-            final double value = sampler.sample();
-            Assert.assertTrue("Value not in range", value >= min && value <= max);
-        }
-    }
-
+public class BoxMullerNormalisedGaussianSamplerTest {
     /**
      * Test the SharedStateSampler implementation.
      */
@@ -56,11 +32,9 @@ public class ContinuousUniformSamplerTest {
     public void testSharedStateSampler() {
         final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
         final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final double low = 1.23;
-        final double high = 4.56;
-        final ContinuousUniformSampler sampler1 =
-            new ContinuousUniformSampler(rng1, low, high);
-        final ContinuousUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        final BoxMullerNormalizedGaussianSampler sampler1 =
+            new BoxMullerNormalizedGaussianSampler(rng1);
+        final BoxMullerNormalizedGaussianSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -50,5 +52,20 @@ public class ChengBetaSamplerTest {
         @SuppressWarnings("unused")
         final ChengBetaSampler sampler =
             new ChengBetaSampler(rng, alpha, beta);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double alpha = 1.23;
+        final double beta = 4.56;
+        final ChengBetaSampler sampler1 =
+            new ChengBetaSampler(rng1, alpha, beta);
+        final ChengBetaSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -34,5 +35,36 @@ public class DiscreteUniformSamplerTest {
         final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
         @SuppressWarnings("unused")
         DiscreteUniformSampler sampler = new DiscreteUniformSampler(rng, lower, upper);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSamplerWithSmallRange() {
+        testSharedStateSampler(5, 67);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSamplerWithLargeRange() {
+        testSharedStateSampler(-99999999, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     *
+     * @param lower Lower.
+     * @param upper Upper.
+     */
+    private static void testSharedStateSampler(int lower, int upper) {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final DiscreteUniformSampler sampler1 =
+            new DiscreteUniformSampler(rng1, lower, upper);
+        final DiscreteUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
@@ -17,6 +17,9 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
+import org.apache.commons.rng.sampling.SharedStateSampler;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -37,5 +40,76 @@ public class GaussianSamplerTest {
         @SuppressWarnings("unused")
         final GaussianSampler sampler =
             new GaussianSampler(gauss, mean, standardDeviation);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng1);
+        final double mean = 1.23;
+        final double standardDeviation = 4.56;
+        final GaussianSampler sampler1 =
+            new GaussianSampler(gauss, mean, standardDeviation);
+        final GaussianSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation throws if the underlying sampler is
+     * not a SharedStateSampler.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSharedStateSamplerThrowsIfUnderlyingSamplerDoesNotShareState() {
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final NormalizedGaussianSampler gauss = new NormalizedGaussianSampler() {
+            @Override
+            public double sample() {
+                return 0;
+            }
+        };
+        final double mean = 1.23;
+        final double standardDeviation = 4.56;
+        final GaussianSampler sampler1 =
+            new GaussianSampler(gauss, mean, standardDeviation);
+        sampler1.withUniformRandomProvider(rng2);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation throws if the underlying sampler is
+     * a SharedStateSampler that returns an incorrect type.
+     */
+    @Test(expected = ClassCastException.class)
+    public void testSharedStateSamplerThrowsIfUnderlyingSamplerReturnsWrongSharedState() {
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final NormalizedGaussianSampler gauss = new BadSharedStateNormalizedGaussianSampler();
+        final double mean = 1.23;
+        final double standardDeviation = 4.56;
+        final GaussianSampler sampler1 =
+            new GaussianSampler(gauss, mean, standardDeviation);
+        sampler1.withUniformRandomProvider(rng2);
+    }
+
+    /**
+     * Test class to return an incorrect sampler from the SharedStateSampler method.
+     *
+     * <p>Note that due to type erasure the type returned by the SharedStateSampler is not
+     * available at run-time and the GaussianSampler has to assume it is the correct type.</p>
+     */
+    private static class BadSharedStateNormalizedGaussianSampler
+            implements NormalizedGaussianSampler, SharedStateSampler<Integer> {
+        @Override
+        public double sample() {
+            return 0;
+        }
+
+        @Override
+        public Integer withUniformRandomProvider(UniformRandomProvider rng) {
+            // Something that is not a NormalizedGaussianSampler
+            return Integer.valueOf(44);
+        }
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
@@ -110,5 +111,36 @@ public class GeometricSamplerTest {
         final double probabilityOfSuccess = 0;
         @SuppressWarnings("unused")
         final GeometricSampler sampler = new GeometricSampler(unusedRng, probabilityOfSuccess);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        testSharedStateSampler(0.5);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation with the edge case when the probability of
+     * success is {@code 1.0}.
+     */
+    @Test
+    public void testSharedStateSamplerWithProbabilityOfSuccessOne() {
+        testSharedStateSampler(1.0);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     *
+     * @param probabilityOfSuccess Probability of success.
+     */
+    private static void testSharedStateSampler(double probabilityOfSuccess) {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final GeometricSampler sampler1 =
+            new GeometricSampler(rng1, probabilityOfSuccess);
+        final GeometricSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSamplerTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.stat.inference.ChiSquareTest;
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
@@ -233,5 +234,19 @@ public class GuideTableDiscreteSamplerTest {
         final ChiSquareTest chiSquareTest = new ChiSquareTest();
         // Pass if we cannot reject null hypothesis that the distributions are the same.
         Assert.assertFalse(chiSquareTest.chiSquareTest(expected, observed, 0.001));
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double[] probabilities = {0.1, 0, 0.2, 0.3, 0.1, 0.3, 0};
+        final GuideTableDiscreteSampler sampler1 =
+            new GuideTableDiscreteSampler(rng1, probabilities);
+        final GuideTableDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSamplerTest.java
@@ -19,48 +19,29 @@ package org.apache.commons.rng.sampling.distribution;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Test for the {@link ContinuousUniformSampler}.
+ * Test for the {@link InverseTransformContinuousSampler}.
  */
-public class ContinuousUniformSamplerTest {
-    /**
-     * Test that the sampler algorithm does not require high to be above low.
-     */
-    @Test
-    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
-        final double low = 3.18;
-        final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
-        testSampleInRange(rng, low, high);
-        testSampleInRange(rng, high, low);
-    }
-
-    private static void testSampleInRange(UniformRandomProvider rng,
-                                          double low, double high) {
-        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
-        final double min = Math.min(low,  high);
-        final double max = Math.max(low,  high);
-        for (int i = 0; i < 10; i++) {
-            final double value = sampler.sample();
-            Assert.assertTrue("Value not in range", value >= min && value <= max);
-        }
-    }
-
+public class InverseTransformContinuousSamplerTest {
     /**
      * Test the SharedStateSampler implementation.
      */
     @Test
     public void testSharedStateSampler() {
+        ContinuousInverseCumulativeProbabilityFunction function =
+            new ContinuousInverseCumulativeProbabilityFunction() {
+                @Override
+                public double inverseCumulativeProbability(double p) {
+                    return 456.99 * p;
+                }
+        };
         final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
         final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final double low = 1.23;
-        final double high = 4.56;
-        final ContinuousUniformSampler sampler1 =
-            new ContinuousUniformSampler(rng1, low, high);
-        final ContinuousUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        final InverseTransformContinuousSampler sampler1 =
+            new InverseTransformContinuousSampler(rng1, function);
+        final InverseTransformContinuousSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSamplerTest.java
@@ -19,48 +19,29 @@ package org.apache.commons.rng.sampling.distribution;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Test for the {@link ContinuousUniformSampler}.
+ * Test for the {@link InverseTransformDiscreteSampler}.
  */
-public class ContinuousUniformSamplerTest {
-    /**
-     * Test that the sampler algorithm does not require high to be above low.
-     */
-    @Test
-    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
-        final double low = 3.18;
-        final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
-        testSampleInRange(rng, low, high);
-        testSampleInRange(rng, high, low);
-    }
-
-    private static void testSampleInRange(UniformRandomProvider rng,
-                                          double low, double high) {
-        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
-        final double min = Math.min(low,  high);
-        final double max = Math.max(low,  high);
-        for (int i = 0; i < 10; i++) {
-            final double value = sampler.sample();
-            Assert.assertTrue("Value not in range", value >= min && value <= max);
-        }
-    }
-
+public class InverseTransformDiscreteSamplerTest {
     /**
      * Test the SharedStateSampler implementation.
      */
     @Test
     public void testSharedStateSampler() {
+        DiscreteInverseCumulativeProbabilityFunction function =
+            new DiscreteInverseCumulativeProbabilityFunction() {
+                @Override
+                public int inverseCumulativeProbability(double p) {
+                    return (int) Math.round(789 * p);
+                }
+        };
         final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
         final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final double low = 1.23;
-        final double high = 4.56;
-        final ContinuousUniformSampler sampler1 =
-            new ContinuousUniformSampler(rng1, low, high);
-        final ContinuousUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        final InverseTransformDiscreteSampler sampler1 =
+            new InverseTransformDiscreteSampler(rng1, function);
+        final InverseTransformDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -31,11 +33,11 @@ public class InverseTransformParetoSamplerTest {
     public void testConstructorThrowsWithZeroScale() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double shape = 1;
         final double scale = 0;
+        final double shape = 1;
         @SuppressWarnings("unused")
         final InverseTransformParetoSampler sampler =
-            new InverseTransformParetoSampler(rng, shape, scale);
+            new InverseTransformParetoSampler(rng, scale, shape);
     }
 
     /**
@@ -45,10 +47,25 @@ public class InverseTransformParetoSamplerTest {
     public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
             RandomSource.create(RandomSource.SPLIT_MIX_64);
-        final double shape = 0;
         final double scale = 1;
+        final double shape = 0;
         @SuppressWarnings("unused")
         final InverseTransformParetoSampler sampler =
-            new InverseTransformParetoSampler(rng, shape, scale);
+            new InverseTransformParetoSampler(rng, scale, shape);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double scale = 1.23;
+        final double shape = 4.56;
+        final InverseTransformParetoSampler sampler1 =
+            new InverseTransformParetoSampler(rng1, scale, shape);
+        final InverseTransformParetoSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
@@ -18,6 +18,8 @@ package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
+import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -142,6 +144,20 @@ public class KempSmallMeanPoissonSamplerTest {
             final int upper = pd.inverseCumulativeProbability(p + 0.01);
             testSample(rng, sampler, p, lower, upper);
         }
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double mean = 1.23;
+        final KempSmallMeanPoissonSampler sampler1 =
+            new KempSmallMeanPoissonSampler(rng1, mean);
+        final KempSmallMeanPoissonSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 
     /**

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
@@ -18,6 +18,8 @@ package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RandomProviderState;
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.sampling.distribution.LargeMeanPoissonSampler.LargeMeanPoissonSamplerState;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
@@ -140,5 +142,36 @@ public class LargeMeanPoissonSamplerTest {
         for (int j = 0; j < 10; j++) {
             Assert.assertEquals("Not the same sample", s1.sample(), s2.sample());
         }
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSamplerWithFractionalMean() {
+        testSharedStateSampler(34.5);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation with the edge case when there is no
+     * small mean sampler (i.e. no fraction part to the mean).
+     */
+    @Test
+    public void testSharedStateSamplerWithIntegerMean() {
+        testSharedStateSampler(34.0);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     *
+     * @param mean Mean.
+     */
+    private static void testSharedStateSampler(double mean) {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final LargeMeanPoissonSampler sampler1 =
+            new LargeMeanPoissonSampler(rng1, mean);
+        final LargeMeanPoissonSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalisedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalisedGaussianSamplerTest.java
@@ -19,36 +19,12 @@ package org.apache.commons.rng.sampling.distribution;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Test for the {@link ContinuousUniformSampler}.
+ * Test for the {@link MarsagliaNormalizedGaussianSampler}.
  */
-public class ContinuousUniformSamplerTest {
-    /**
-     * Test that the sampler algorithm does not require high to be above low.
-     */
-    @Test
-    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
-        final double low = 3.18;
-        final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
-        testSampleInRange(rng, low, high);
-        testSampleInRange(rng, high, low);
-    }
-
-    private static void testSampleInRange(UniformRandomProvider rng,
-                                          double low, double high) {
-        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
-        final double min = Math.min(low,  high);
-        final double max = Math.max(low,  high);
-        for (int i = 0; i < 10; i++) {
-            final double value = sampler.sample();
-            Assert.assertTrue("Value not in range", value >= min && value <= max);
-        }
-    }
-
+public class MarsagliaNormalisedGaussianSamplerTest {
     /**
      * Test the SharedStateSampler implementation.
      */
@@ -56,11 +32,9 @@ public class ContinuousUniformSamplerTest {
     public void testSharedStateSampler() {
         final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
         final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final double low = 1.23;
-        final double high = 4.56;
-        final ContinuousUniformSampler sampler1 =
-            new ContinuousUniformSampler(rng1, low, high);
-        final ContinuousUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        final MarsagliaNormalizedGaussianSampler sampler1 =
+            new MarsagliaNormalizedGaussianSampler(rng1);
+        final MarsagliaNormalizedGaussianSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerTest.java
@@ -19,48 +19,40 @@ package org.apache.commons.rng.sampling.distribution;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Test for the {@link ContinuousUniformSampler}.
+ * This test checks the {@link PoissonSampler} can be created
+ * from a saved state.
  */
-public class ContinuousUniformSamplerTest {
+public class PoissonSamplerTest {
     /**
-     * Test that the sampler algorithm does not require high to be above low.
+     * Test the SharedStateSampler implementation with a mean below 40.
      */
     @Test
-    public void testNoRestrictionOnOrderOfLowAndHighParameters() {
-        final double low = 3.18;
-        final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
-        testSampleInRange(rng, low, high);
-        testSampleInRange(rng, high, low);
+    public void testSharedStateSamplerWithSmallMean() {
+        testSharedStateSampler(34.5);
     }
 
-    private static void testSampleInRange(UniformRandomProvider rng,
-                                          double low, double high) {
-        ContinuousUniformSampler sampler = new ContinuousUniformSampler(rng, low, high);
-        final double min = Math.min(low,  high);
-        final double max = Math.max(low,  high);
-        for (int i = 0; i < 10; i++) {
-            final double value = sampler.sample();
-            Assert.assertTrue("Value not in range", value >= min && value <= max);
-        }
+    /**
+     * Test the SharedStateSampler implementation with a mean above 40.
+     */
+    @Test
+    public void testSharedStateSamplerWithLargeMean() {
+        testSharedStateSampler(67.8);
     }
 
     /**
      * Test the SharedStateSampler implementation.
+     *
+     * @param mean Mean.
      */
-    @Test
-    public void testSharedStateSampler() {
+    private static void testSharedStateSampler(double mean) {
         final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
         final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final double low = 1.23;
-        final double high = 4.56;
-        final ContinuousUniformSampler sampler1 =
-            new ContinuousUniformSampler(rng1, low, high);
-        final ContinuousUniformSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        final PoissonSampler sampler1 =
+            new PoissonSampler(rng1, mean);
+        final PoissonSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Test;
 
@@ -50,5 +52,20 @@ public class RejectionInversionZipfSamplerTest {
         @SuppressWarnings("unused")
         final RejectionInversionZipfSampler sampler =
             new RejectionInversionZipfSampler(rng, numberOfElements, exponent);
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final int numberOfElements = 7;
+        final double exponent = 1.23;
+        final RejectionInversionZipfSampler sampler1 =
+            new RejectionInversionZipfSampler(rng1, numberOfElements, exponent);
+        final RejectionInversionZipfSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSamplerTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.rng.sampling.distribution;
 
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.Assert;
 import org.junit.Test;
@@ -76,5 +77,19 @@ public class SmallMeanPoissonSamplerTest {
             final int expected = (int) Math.ceil(1000 * mean);
             Assert.assertEquals(expected, sampler.sample());
         }
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final double mean = 1.23;
+        final SmallMeanPoissonSampler sampler1 =
+            new SmallMeanPoissonSampler(rng1, mean);
+        final SmallMeanPoissonSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSamplerTest.java
@@ -18,6 +18,8 @@ package org.apache.commons.rng.sampling.distribution;
 
 import org.junit.Test;
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.RandomAssert;
+import org.apache.commons.rng.simple.RandomSource;
 
 /**
  * Test for {@link ZigguratNormalizedGaussianSampler}.
@@ -44,5 +46,18 @@ public class ZigguratNormalizedGaussianSamplerTest {
 
         // Infinite loop (in v1.1).
         new ZigguratNormalizedGaussianSampler(bad).sample();
+    }
+
+    /**
+     * Test the SharedStateSampler implementation.
+     */
+    @Test
+    public void testSharedStateSampler() {
+        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final ZigguratNormalizedGaussianSampler sampler1 =
+            new ZigguratNormalizedGaussianSampler(rng1);
+        final ZigguratNormalizedGaussianSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
+        RandomAssert.assertProduceSameSequence(sampler1, sampler2);
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -75,6 +75,10 @@ re-run tests that fail, and pass the build if they succeed
 within the allotted number of reruns (the test will be marked
 as 'flaky' in the report).
 ">
+      <action dev="aherbert" type="add" issue="102">
+        New "SharedStateSampler" interface to allow a sampler to create a new instance with
+        a new source of randomness. Any pre-computed state can be shared between the samplers.
+      </action>
       <action dev="aherbert" type="add" issue="108">
         Update "SeedFactory" to improve performance.
       </action>

--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -22,6 +22,8 @@
   <!-- Special cases with many parameters for the constructor. -->
   <suppress checks="ParameterNumber" files="[\\/]LargeMeanPoissonSampler\.java$" />
   <suppress checks="ParameterNumber" files="source64[\\/].*XoShiRo512.*\.java$" />
+  <!-- Special to allow withUniformRandomProvider to act as a constructor. -->
+  <suppress checks="HiddenField" files=".*Sampler\.java$" message="'rng' hides a field." />
   <!-- Be more lenient on tests. -->
   <suppress checks="Javadoc" files=".*[/\\]test[/\\].*" />
   <suppress checks="MultipleStringLiterals" files=".*[/\\]test[/\\].*" />

--- a/src/main/resources/pmd/pmd-ruleset.xml
+++ b/src/main/resources/pmd/pmd-ruleset.xml
@@ -121,6 +121,12 @@
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='AliasMethodDiscreteSampler']"/>
     </properties>
   </rule>
+  <rule ref="category/java/design.xml/ExcessiveClassLength">
+    <properties>
+      <!-- The length is due to multiple implementations as inner classes -->
+      <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@Image='MarsagliaTsangWangDiscreteSampler']"/>
+    </properties>
+  </rule>
 
   <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition">
     <properties>


### PR DESCRIPTION
Implement a SharedStateSampler interface for all samplers.

This allows a sampler to create a new sampler of the same distribution with a new source of randomness. This can be used to share state if the state is large and create multiple samplers for concurrent usage.