### PR TITLE
Update travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,12 @@ jdk:
   - openjdk8
   - oraclejdk9
 
+# Skip the installation step:
+#   https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase
+install: true
+
+script:
+  - mvn
+
 after_success:
-  - mvn clean test pmd:check spotbugs:check checkstyle:check jacoco:report coveralls:report
+  - mvn jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -296,13 +296,19 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-         <!--  Should agree with apache-rat-plugin config under <build> -->
+          <!--  Should agree with apache-rat-plugin config under <build> -->
           <excludes combine.children="append">
             <!-- version 0.8 of apache-rat-plugin does not exclude properly
                  some default development tools files (see RAT-126) -->
             <exclude>.ekstazi/**</exclude>
-            <exclude>src/site/resources/txt/userguide/stress/dh/**</exclude>
-            <exclude>src/site/resources/txt/userguide/stress/tu/**</exclude>
+            <exclude>**/site-content/**</exclude>
+            <exclude>**/.classpath</exclude>
+            <exclude>**/.project</exclude>
+            <exclude>**/.settings/**</exclude>
+            <exclude>**/.checkstyle</exclude>
+            <exclude>**/target/**</exclude>
+            <exclude>src/site/resources/release-notes/RELEASE-NOTES-*.txt</exclude>
+            <exclude>src/site/resources/txt/userguide/stress/**</exclude>
             <exclude>dist-archive/**</exclude>
           </excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,6 @@
     <!-- Fix to build on JDK 7: version 4.0.0 requires Java 8. -->
     <commons.felix.version>3.5.1</commons.felix.version>
 
-    <commons.jacoco.classRatio>0.96</commons.jacoco.classRatio>
-    <commons.jacoco.instructionRatio>0.8</commons.jacoco.instructionRatio>
-    <commons.jacoco.methodRatio>0.8</commons.jacoco.methodRatio>
-    <commons.jacoco.branchRatio>0.8</commons.jacoco.branchRatio>
-    <commons.jacoco.complexityRatio>0.8</commons.jacoco.complexityRatio>
-    <commons.jacoco.lineRatio>0.85</commons.jacoco.lineRatio>
     <commons.jacoco.haltOnFailure>false</commons.jacoco.haltOnFailure>
 
     <commons.site.path>rng</commons.site.path>
@@ -510,64 +504,30 @@
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${commons.jacoco.version}</version>
-            <executions>
-              <execution>
-                <id>default-prepare-agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-prepare-agent-integration</id>
-                <goals>
-                  <goal>prepare-agent-integration</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-report</id>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-report-integration</id>
-                <goals>
-                  <goal>report-integration</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <!--  implementation is needed only for Maven 2  -->
-                    <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>BUNDLE</element>
-                      <limits>
-                        <!--  implementation is needed only for Maven 2  -->
-                        <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>COMPLEXITY</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.60</minimum>
-                        </limit>
-                      </limits>
-                    </rule>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <groupId>org.eluder.coveralls</groupId>
             <artifactId>coveralls-maven-plugin</artifactId>
+            <!-- Version for JDK 6 target. -->
             <version>3.1.0</version>
+            <configuration>
+              <timestampFormat>${commons.coveralls.timestampFormat}</timestampFormat>
+            </configuration>
           </plugin>
         </plugins>
       </build>
     </profile>
-    <!-- profile to allow the use of plugin versions that require Java 8+ -->
+    <!-- Profile to alter default Maven goal as it uses checks from Java 8+ plugins. -->
+    <profile>
+      <id>pre-jdk8</id>
+      <activation>
+        <jdk>[1.6,1.8)</jdk>
+      </activation>
+      <build>
+        <defaultGoal>clean verify</defaultGoal>
+      </build>
+    </profile>
+    <!-- Profile to allow the use of plugin versions that require Java 8+ -->
     <profile>
       <id>jdk8-plugins</id>
       <activation>


### PR DESCRIPTION
This is a test PR to see if an updated coverage/travis configuration is OK. The update is to run the default Maven goal. This adds apache-rat:check and javadoc:javadoc goals to those currently tested.

It removes the customisation of the jacoco coverage rules so that the commons parent is used. This makes the checks stricter but coverage is high so this is fine.

Previously checks were performed in the after_success phase which is allowed to fail. Thus if checks failed then this would be lost and checks had no effect on reporting bad PRs. This updates to run the default maven goal with all checks. If successful then coverage reports will be submitted.

A profile has been added to disable checks in the JDK 7 build as this uses plugins that require JDK 8.
