### PR TITLE
RNG-115: Fix JDKRandom to restore state to a new instance.

### DIFF
--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/JDKRandomTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source32/JDKRandomTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.rng.core.source32;
 
 import java.util.Random;
 
+import org.apache.commons.rng.RandomProviderState;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,6 +34,34 @@ public class JDKRandomTest {
         final int numRepeats = 1000;
         for (int r = 0; r < numRepeats; r++) {
             Assert.assertEquals(r + " nextInt", jdk.nextInt(), rng.nextInt());
+        }
+    }
+
+    /**
+     * Test the state can be used to restore a new instance that has not previously had a call
+     * to save the state.
+     */
+    @Test
+    public void testRestoreToNewInstance()  {
+        final long seed = 8796746234L;
+        final JDKRandom rng1 = new JDKRandom(seed);
+        final JDKRandom rng2 = new JDKRandom(seed + 1);
+
+        // Ensure different
+        final int numRepeats = 10;
+        for (int r = 0; r < numRepeats; r++) {
+            Assert.assertNotEquals(r + " nextInt", rng1.nextInt(), rng2.nextInt());
+        }
+
+        final RandomProviderState state = rng1.saveState();
+        // This second instance will not know the state size required to write
+        // java.util.Random to serialized form. This is only known when the saveState
+        // method is called.
+        rng2.restoreState(state);
+
+        // Ensure the same
+        for (int r = 0; r < numRepeats; r++) {
+            Assert.assertEquals(r + " nextInt", rng1.nextInt(), rng2.nextInt());
         }
     }
 }


### PR DESCRIPTION
Save the state size to the byte array representation. This can be read
by any instance when restoring.