### PR TITLE
RNG-136: Add ObjectSampler<T> and SharedStateObjectSampler<T> interfaces

### DIFF
--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TetrahedronSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TetrahedronSamplerBenchmark.java
@@ -432,10 +432,10 @@ public class TetrahedronSamplerBenchmark {
             // This could be configured using @Param
             final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_256_PP);
             final UnitSphereSampler s = UnitSphereSampler.of(3, rng);
-            final double[] a = s.nextVector();
-            final double[] b = s.nextVector();
-            final double[] c = s.nextVector();
-            final double[] d = s.nextVector();
+            final double[] a = s.sample();
+            final double[] b = s.sample();
+            final double[] c = s.sample();
+            final double[] d = s.sample();
             sampler = createSampler(a, b, c, d, rng);
         }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TriangleSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TriangleSamplerBenchmark.java
@@ -205,9 +205,9 @@ public class TriangleSamplerBenchmark {
             final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
             final int dimension = getDimension();
             final UnitSphereSampler s = UnitSphereSampler.of(dimension, rng);
-            final double[] a = s.nextVector();
-            final double[] b = s.nextVector();
-            final double[] c = s.nextVector();
+            final double[] a = s.sample();
+            final double[] b = s.sample();
+            final double[] c = s.sample();
             sampler = createSampler(a, b, c, rng);
         }
 

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CollectionSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CollectionSampler.java
@@ -32,7 +32,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  *
  * @since 1.0
  */
-public class CollectionSampler<T> implements SharedStateSampler<CollectionSampler<T>> {
+public class CollectionSampler<T> implements SharedStateObjectSampler<T> {
     /** Collection to be sampled from. */
     private final List<T> items;
     /** RNG. */
@@ -73,6 +73,7 @@ public class CollectionSampler<T> implements SharedStateSampler<CollectionSample
      *
      * @return a random sample.
      */
+    @Override
     public T sample() {
         return items.get(rng.nextInt(items.size()));
     }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CombinationSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/CombinationSampler.java
@@ -39,7 +39,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  *
  * @see PermutationSampler
  */
-public class CombinationSampler implements SharedStateSampler<CombinationSampler> {
+public class CombinationSampler implements SharedStateObjectSampler<int[]> {
     /** Domain of the combination. */
     private final int[] domain;
     /** The number of steps of a full shuffle to perform. */
@@ -117,6 +117,7 @@ public class CombinationSampler implements SharedStateSampler<CombinationSampler
      *
      * @return a random combination.
      */
+    @Override
     public int[] sample() {
         return SubsetSamplerUtils.partialSample(domain, steps, rng, upper);
     }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSampler.java
@@ -38,8 +38,7 @@ import org.apache.commons.rng.sampling.distribution.SharedStateDiscreteSampler;
  *
  * @since 1.1
  */
-public class DiscreteProbabilityCollectionSampler<T>
-    implements SharedStateSampler<DiscreteProbabilityCollectionSampler<T>> {
+public class DiscreteProbabilityCollectionSampler<T> implements SharedStateObjectSampler<T> {
     /** The error message for an empty collection. */
     private static final String EMPTY_COLLECTION = "Empty collection";
     /** Collection to be sampled from. */
@@ -131,6 +130,7 @@ public class DiscreteProbabilityCollectionSampler<T>
      *
      * @return a random sample.
      */
+    @Override
     public T sample() {
         return items.get(sampler.sample());
     }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/ObjectSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/ObjectSampler.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.sampling;
+
+/**
+ * Sampler that generates values of a specified type.
+ *
+ * @param <T> Type of the sample.
+ * @since 1.4
+ */
+public interface ObjectSampler<T> {
+    /**
+     * Create a sample.
+     *
+     * @return a sample
+     */
+    T sample();
+}

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/PermutationSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/PermutationSampler.java
@@ -27,7 +27,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  *
  * <p>This class also contains utilities for shuffling an {@code int[]} array in-place.</p>
  */
-public class PermutationSampler implements SharedStateSampler<PermutationSampler> {
+public class PermutationSampler implements SharedStateObjectSampler<int[]> {
     /** Domain of the permutation. */
     private final int[] domain;
     /** Size of the permutation. */
@@ -82,6 +82,7 @@ public class PermutationSampler implements SharedStateSampler<PermutationSampler
      *
      * @see #PermutationSampler(UniformRandomProvider,int,int)
      */
+    @Override
     public int[] sample() {
         return SubsetSamplerUtils.partialSample(domain, size, rng, true);
     }

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/SharedStateObjectSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/SharedStateObjectSampler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.sampling;
+
+/**
+ * Sampler that generates values of a specified type and can create new instances to sample
+ * from the same state with a given source of randomness.
+ *
+ * @param <T> Type of the sample.
+ * @since 1.4
+ */
+public interface SharedStateObjectSampler<T> extends
+    ObjectSampler<T>, SharedStateSampler<SharedStateObjectSampler<T>> {
+    // Composite interface
+}

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/UnitSphereSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/UnitSphereSampler.java
@@ -37,7 +37,7 @@ import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSa
  *
  * @since 1.1
  */
-public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> {
+public class UnitSphereSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 1D sampling. */
     private static final int ONE_D = 1;
     /** The dimension for 2D sampling. */
@@ -69,7 +69,7 @@ public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> 
         }
 
         @Override
-        public double[] nextVector() {
+        public double[] sample() {
             // Either:
             // 1 - 0 = 1
             // 1 - 2 = -1
@@ -99,7 +99,7 @@ public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> 
         }
 
         @Override
-        public double[] nextVector() {
+        public double[] sample() {
             final double x = sampler.sample();
             final double y = sampler.sample();
             final double sum = x * x + y * y;
@@ -135,7 +135,7 @@ public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> 
         }
 
         @Override
-        public double[] nextVector() {
+        public double[] sample() {
             final double x = sampler.sample();
             final double y = sampler.sample();
             final double z = sampler.sample();
@@ -175,7 +175,7 @@ public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> 
         }
 
         @Override
-        public double[] nextVector() {
+        public double[] sample() {
             final double[] v = new double[dimension];
 
             // Pick a point by choosing a standard Gaussian for each element,
@@ -234,9 +234,20 @@ public class UnitSphereSampler implements SharedStateSampler<UnitSphereSampler> 
 
     /**
      * @return a random normalized Cartesian vector.
+     * @since 1.4
      */
+    @Override
+    public double[] sample() {
+        return delegate.sample();
+    }
+
+    /**
+     * @return a random normalized Cartesian vector.
+     * @deprecated Use {@link #sample()}.
+     */
+    @Deprecated
     public double[] nextVector() {
-        return delegate.nextVector();
+        return sample();
     }
 
     /**

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/BoxSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/BoxSampler.java
@@ -18,7 +18,7 @@
 package org.apache.commons.rng.sampling.shape;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.SharedStateSampler;
+import org.apache.commons.rng.sampling.SharedStateObjectSampler;
 
 /**
  * Generate points uniformly distributed within a n-dimension box (hyperrectangle).
@@ -32,7 +32,7 @@ import org.apache.commons.rng.sampling.SharedStateSampler;
  * @see <a href="https://en.wikipedia.org/wiki/Hyperrectangle">Hyperrectangle (Wikipedia)</a>
  * @since 1.4
  */
-public abstract class BoxSampler implements SharedStateSampler<BoxSampler> {
+public abstract class BoxSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 2D sampling. */
     private static final int TWO_D = 2;
     /** The dimension for 3D sampling. */
@@ -214,6 +214,7 @@ public abstract class BoxSampler implements SharedStateSampler<BoxSampler> {
     /**
      * @return a random Cartesian coordinate within the box.
      */
+    @Override
     public abstract double[] sample();
 
     /**
@@ -227,6 +228,11 @@ public abstract class BoxSampler implements SharedStateSampler<BoxSampler> {
         final double u = rng.nextDouble();
         return (1.0 - u) * a + u * b;
     }
+
+    /** {@inheritDoc} */
+    // Redeclare the signature to return a BoxSampler not a SharedStateObjectSampler<double[]>
+    @Override
+    public abstract BoxSampler withUniformRandomProvider(UniformRandomProvider rng);
 
     /**
      * Create a box sampler with bounds {@code a} and {@code b}.

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/LineSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/LineSampler.java
@@ -18,7 +18,7 @@
 package org.apache.commons.rng.sampling.shape;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.SharedStateSampler;
+import org.apache.commons.rng.sampling.SharedStateObjectSampler;
 
 /**
  * Generate points uniformly distributed on a line.
@@ -31,7 +31,7 @@ import org.apache.commons.rng.sampling.SharedStateSampler;
  *
  * @since 1.4
  */
-public abstract class LineSampler implements SharedStateSampler<LineSampler> {
+public abstract class LineSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 1D sampling. */
     private static final int ONE_D = 1;
     /** The dimension for 2D sampling. */
@@ -261,6 +261,7 @@ public abstract class LineSampler implements SharedStateSampler<LineSampler> {
     /**
      * @return a random Cartesian coordinate on the line.
      */
+    @Override
     public double[] sample() {
         final double u = rng.nextDouble();
         return createSample(1.0 - u, u);
@@ -279,6 +280,11 @@ public abstract class LineSampler implements SharedStateSampler<LineSampler> {
      * @return the sample
      */
     protected abstract double[] createSample(double p1mu, double u);
+
+    /** {@inheritDoc} */
+    // Redeclare the signature to return a LineSampler not a SharedStateObjectSampler<double[]>
+    @Override
+    public abstract LineSampler withUniformRandomProvider(UniformRandomProvider rng);
 
     /**
      * Create a line sampler with vertices {@code a} and {@code b}.

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/TetrahedronSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/TetrahedronSampler.java
@@ -18,7 +18,7 @@
 package org.apache.commons.rng.sampling.shape;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.SharedStateSampler;
+import org.apache.commons.rng.sampling.SharedStateObjectSampler;
 
 /**
  * Generate points uniformly distributed within a
@@ -45,7 +45,7 @@ import org.apache.commons.rng.sampling.SharedStateSampler;
  *   Rocchini, C. &amp; Cignoni, P. (2001) Journal of Graphics Tools 5, pp. 9-12</a>
  * @since 1.4
  */
-public class TetrahedronSampler implements SharedStateSampler<TetrahedronSampler> {
+public class TetrahedronSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 3D sampling. */
     private static final int THREE_D = 3;
     /** The name of vertex a. */
@@ -100,6 +100,7 @@ public class TetrahedronSampler implements SharedStateSampler<TetrahedronSampler
     /**
      * @return a random Cartesian point within the tetrahedron.
      */
+    @Override
     public double[] sample() {
         double s = rng.nextDouble();
         double t = rng.nextDouble();

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/TriangleSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/TriangleSampler.java
@@ -18,7 +18,7 @@
 package org.apache.commons.rng.sampling.shape;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.SharedStateSampler;
+import org.apache.commons.rng.sampling.SharedStateObjectSampler;
 
 /**
  * Generate points <a href="https://mathworld.wolfram.com/TrianglePointPicking.html">
@@ -42,7 +42,7 @@ import org.apache.commons.rng.sampling.SharedStateSampler;
  *
  * @since 1.4
  */
-public abstract class TriangleSampler implements SharedStateSampler<TriangleSampler> {
+public abstract class TriangleSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 2D sampling. */
     private static final int TWO_D = 2;
     /** The dimension for 3D sampling. */
@@ -273,6 +273,7 @@ public abstract class TriangleSampler implements SharedStateSampler<TriangleSamp
     /**
      * @return a random Cartesian coordinate within the triangle.
      */
+    @Override
     public double[] sample() {
         final double s = rng.nextDouble();
         final double t = rng.nextDouble();
@@ -303,6 +304,11 @@ public abstract class TriangleSampler implements SharedStateSampler<TriangleSamp
      * @return the sample
      */
     protected abstract double[] createSample(double p1msmt, double s, double t);
+
+    /** {@inheritDoc} */
+    // Redeclare the signature to return a TriangleSampler not a SharedStateObjectSampler<double[]>
+    @Override
+    public abstract TriangleSampler withUniformRandomProvider(UniformRandomProvider rng);
 
     /**
      * Create a triangle sampler with vertices {@code a}, {@code b} and {@code c}.

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/UnitBallSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/shape/UnitBallSampler.java
@@ -18,7 +18,7 @@
 package org.apache.commons.rng.sampling.shape;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.sampling.SharedStateSampler;
+import org.apache.commons.rng.sampling.SharedStateObjectSampler;
 import org.apache.commons.rng.sampling.distribution.NormalizedGaussianSampler;
 import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSampler;
 
@@ -35,7 +35,7 @@ import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSa
  *
  * @since 1.4
  */
-public abstract class UnitBallSampler implements SharedStateSampler<UnitBallSampler> {
+public abstract class UnitBallSampler implements SharedStateObjectSampler<double[]> {
     /** The dimension for 1D sampling. */
     private static final int ONE_D = 1;
     /** The dimension for 2D sampling. */
@@ -196,7 +196,13 @@ public abstract class UnitBallSampler implements SharedStateSampler<UnitBallSamp
     /**
      * @return a random Cartesian coordinate within the unit n-ball.
      */
+    @Override
     public abstract double[] sample();
+
+    /** {@inheritDoc} */
+    // Redeclare the signature to return a UnitBallSampler not a SharedStateObjectSampler<double[]>
+    @Override
+    public abstract UnitBallSampler withUniformRandomProvider(UniformRandomProvider rng);
 
     /**
      * Create a unit n-ball sampler for the given dimension.

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
@@ -74,6 +74,8 @@ public class UnitSphereSamplerTest {
         // Count the negatives.
         int count = 0;
         for (int i = 0; i < samples; i++) {
+            // Test the deprecated method once in the test suite.
+            @SuppressWarnings("deprecation")
             final double[] v = generator.nextVector();
             Assert.assertEquals(1, v.length);
             final double d = v[0];
@@ -146,7 +148,7 @@ public class UnitSphereSamplerTest {
         final long[] observed = new long[angleBins];
         final int steps = 100000;
         for (int i = 0; i < steps; ++i) {
-            final double[] v = generator.nextVector();
+            final double[] v = generator.sample();
             Assert.assertEquals(2, v.length);
             Assert.assertEquals(1.0, length(v), 1e-10);
             // Get the polar angle bin from xy
@@ -196,7 +198,7 @@ public class UnitSphereSamplerTest {
         final long[] observed = new long[angleBins * depthBins];
         final int steps = 1000000;
         for (int i = 0; i < steps; ++i) {
-            final double[] v = generator.nextVector();
+            final double[] v = generator.sample();
             Assert.assertEquals(3, v.length);
             Assert.assertEquals(1.0, length(v), 1e-10);
             // Get the polar angle bin from xy
@@ -267,7 +269,7 @@ public class UnitSphereSamplerTest {
         final long[] observed2 = new long[observed1.length];
         final int steps = 1000000;
         for (int i = 0; i < steps; ++i) {
-            final double[] v = generator.nextVector();
+            final double[] v = generator.sample();
             Assert.assertEquals(4, v.length);
             Assert.assertEquals(1.0, length(v), 1e-10);
             // Circle 1
@@ -382,7 +384,7 @@ public class UnitSphereSamplerTest {
             }
         };
 
-        UnitSphereSampler.of(dimension, bad).nextVector();
+        UnitSphereSampler.of(dimension, bad).sample();
     }
 
     /**
@@ -427,7 +429,7 @@ public class UnitSphereSamplerTest {
             }
         };
 
-        final double[] vector = UnitSphereSampler.of(dimension, bad).nextVector();
+        final double[] vector = UnitSphereSampler.of(dimension, bad).sample();
         Assert.assertEquals(dimension, vector.length);
         Assert.assertEquals(1.0, length(vector), 1e-10);
     }
@@ -526,13 +528,13 @@ public class UnitSphereSamplerTest {
             new RandomAssert.Sampler<double[]>() {
                 @Override
                 public double[] sample() {
-                    return sampler1.nextVector();
+                    return sampler1.sample();
                 }
             },
             new RandomAssert.Sampler<double[]>() {
                 @Override
                 public double[] sample() {
-                    return sampler2.nextVector();
+                    return sampler2.sample();
                 }
             });
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/BoxSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/BoxSamplerTest.java
@@ -194,8 +194,8 @@ public class BoxSamplerTest {
         final UniformRandomProvider rng = RandomSource.create(RandomSource.JSF_64, 0xdabfab);
 
         final UnitSphereSampler sphere = UnitSphereSampler.of(dimension, rng);
-        final double[] a = sphere.nextVector();
-        final double[] b = sphere.nextVector();
+        final double[] a = sphere.sample();
+        final double[] b = sphere.sample();
 
         // Assign bins
         final int bins = 10;

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/LineSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/LineSamplerTest.java
@@ -218,8 +218,8 @@ public class LineSamplerTest {
             b = new double[] {-rng.nextDouble()};
         } else {
             final UnitSphereSampler sphere = UnitSphereSampler.of(dimension, rng);
-            a = sphere.nextVector();
-            b = sphere.nextVector();
+            a = sphere.sample();
+            b = sphere.sample();
         }
 
         // To test uniformity on the line all fractional lengths along each dimension

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -76,6 +76,19 @@ within the allotted number of reruns (the test will be marked
 as 'flaky' in the report).
 ">
       <action dev="aherbert" type="add" issue="135">
+        New "ObjectSampler&lt;T&gt;" and "SharedStateObjectSampler&lt;T&gt;" interfaces.
+        These interfaces are implemented by samplers returning an object.<br/>
+        This changes the functional compatibility of existing samplers that implement
+        SharedStatedSampler&lt;R&gt;: CollectionSampler&lt;T&gt;; CombinationSampler;
+        DiscreteProbabilityCollectionSampler&lt;T&gt;; PermutationSampler; and UnitSphereSampler.
+        The method signature of the SharedStateSampler&lt;R&gt; interface remains
+        'public R withUniformRandomProvider(UniformRandomProvider)'. The result can still be
+        assigned to an instance of the same class R; it can no longer be assigned to an instance of
+        SharedStatedSampler&lt;R&gt;. It can now be assigned to SharedStateObjectSampler&lt;T&gt;
+        which can be used to generate samples of type &lt;T&gt;.
+        Code that assigned to SharedStatedSampler&lt;R&gt; should be updated.
+      </action>
+      <action dev="aherbert" type="add" issue="135">
         New "TetrahedronSampler" to sample uniformly from a tetrahedron.
       </action>
       <action dev="aherbert" type="add" issue="134">


### PR DESCRIPTION
Add generic ObjectSampler interfaces. These are the object typed equivalent to the DiscreteSampler and SharedStateDiscreteSampler interfaces (which return samples of int).

Deprecate the UnitSphereSampler.nextVector method. It is replaced by the
ObjectSampler.sample method.