### PR TITLE
RNG-143: Add a RandomSource.create() instance method

### DIFF
--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/RandomSources.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/RandomSources.java
@@ -18,14 +18,13 @@
 package org.apache.commons.rng.examples.jmh;
 
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.simple.RandomSource;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 /**
- * A benchmark state that can retrieve the various generators defined by {@link RandomSource}
- * values.
+ * A benchmark state that can retrieve the various generators defined by
+ * {@link org.apache.commons.rng.simple.RandomSource RandomSource} values.
  *
  * <p>The state will include only those that do not require additional constructor arguments.</p>
  */
@@ -44,12 +43,13 @@ public class RandomSources extends RandomSourceValues {
     }
 
     /**
-     * Look-up the {@link RandomSource} from the name and instantiates the generator.
+     * Look-up the {@link org.apache.commons.rng.simple.RandomSource RandomSource} from the
+     * name and instantiates the generator.
      */
     @Override
     @Setup
     public void setup() {
         super.setup();
-        generator = RandomSource.create(getRandomSource());
+        generator = getRandomSource().create();
     }
 }

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/BaselineSources.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/BaselineSources.java
@@ -129,7 +129,7 @@ public abstract class BaselineSources {
             provider = createBaseline();
         } else {
             final RandomSource randomSource = RandomSource.valueOf(randomSourceName);
-            provider = RandomSource.create(randomSource);
+            provider = randomSource.create();
         }
     }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/UnitSphereSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/UnitSphereSamplerBenchmark.java
@@ -105,7 +105,7 @@ public class UnitSphereSamplerBenchmark {
         @Setup
         public void setup() {
             // This could be configured using @Param
-            final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+            final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
             sampler = createSampler(rng);
         }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/AliasMethodDiscreteSamplerPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/AliasMethodDiscreteSamplerPerformance.java
@@ -102,7 +102,7 @@ public class AliasMethodDiscreteSamplerPerformance {
         @Setup
         public void setup() {
             probabilities = createProbabilities(size);
-            final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+            final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
             sampler = AliasMethodDiscreteSampler.of(rng, probabilities, alpha);
         }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/DiscreteUniformSamplerGenerationPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/DiscreteUniformSamplerGenerationPerformance.java
@@ -93,7 +93,7 @@ public class DiscreteUniformSamplerGenerationPerformance {
         @Setup
         public void setup() {
             final RandomSource randomSource = RandomSource.valueOf(randomSourceName);
-            generator = RandomSource.create(randomSource);
+            generator = randomSource.create();
         }
     }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/EnumeratedDistributionSamplersPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/EnumeratedDistributionSamplersPerformance.java
@@ -96,7 +96,7 @@ public class EnumeratedDistributionSamplersPerformance {
         @Setup
         public void setup() {
             final RandomSource randomSource = RandomSource.valueOf(randomSourceName);
-            generator = RandomSource.create(randomSource);
+            generator = randomSource.create();
         }
     }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/GeometricSamplersPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/GeometricSamplersPerformance.java
@@ -100,7 +100,7 @@ public class GeometricSamplersPerformance {
         @Setup
         public void setup() {
             final RandomSource randomSource = RandomSource.valueOf(randomSourceName);
-            final UniformRandomProvider rng = RandomSource.create(randomSource);
+            final UniformRandomProvider rng = randomSource.create();
             if ("GeometricSampler".equals(samplerType)) {
                 sampler = GeometricSampler.of(rng, probabilityOfSuccess);
             } else {

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/PoissonSamplerCachePerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/PoissonSamplerCachePerformance.java
@@ -158,7 +158,7 @@ public class PoissonSamplerCachePerformance {
     static {
         // Build a random seed for all the tests
         SEED = new int[SEED_SIZE];
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.MWC_256);
+        final UniformRandomProvider rng = RandomSource.MWC_256.create();
         for (int i = 0; i < SEED.length; i++) {
             SEED[i] = rng.nextInt();
         }
@@ -219,7 +219,7 @@ public class PoissonSamplerCachePerformance {
             final RandomSource randomSource = RandomSource
                     .valueOf(randomSourceName);
             // Use the same seed
-            generator = RandomSource.create(randomSource, SEED.clone());
+            generator = randomSource.create(SEED.clone());
             state = generator.saveState();
         }
     }

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/PoissonSamplersPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/distribution/PoissonSamplersPerformance.java
@@ -178,7 +178,7 @@ public class PoissonSamplersPerformance {
         @Setup
         public void setup() {
             final RandomSource randomSource = RandomSource.valueOf(randomSourceName);
-            generator = RandomSource.create(randomSource);
+            generator = randomSource.create();
 
             // This would benefit from Java 8 Supplier<DiscreteSampler> lambda function
             if ("SmallMeanPoissonSampler".equals(samplerType)) {

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TetrahedronSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TetrahedronSamplerBenchmark.java
@@ -430,7 +430,7 @@ public class TetrahedronSamplerBenchmark {
         @Setup(Level.Iteration)
         public void setup() {
             // This could be configured using @Param
-            final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_256_PP);
+            final UniformRandomProvider rng = RandomSource.XO_SHI_RO_256_PP.create();
             final UnitSphereSampler s = UnitSphereSampler.of(3, rng);
             final double[] a = s.sample();
             final double[] b = s.sample();

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TriangleSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/TriangleSamplerBenchmark.java
@@ -202,7 +202,7 @@ public class TriangleSamplerBenchmark {
         @Setup(Level.Iteration)
         public void setup() {
             // This could be configured using @Param
-            final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+            final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
             final int dimension = getDimension();
             final UnitSphereSampler s = UnitSphereSampler.of(dimension, rng);
             final double[] a = s.sample();

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/UnitBallSamplerBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/sampling/shape/UnitBallSamplerBenchmark.java
@@ -131,7 +131,7 @@ public class UnitBallSamplerBenchmark {
         @Setup
         public void setup() {
             // This could be configured using @Param
-            final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+            final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
             sampler = createSampler(rng);
         }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/ConstructionPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/ConstructionPerformance.java
@@ -126,7 +126,7 @@ public class ConstructionPerformance {
         LONG_ARRAY_SEEDS = new long[SEEDS][];
         INT_ARRAY_SEEDS = new int[SEEDS][];
         BYTE_ARRAY_SEEDS = new byte[SEEDS][];
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XOR_SHIFT_1024_S_PHI);
+        final UniformRandomProvider rng = RandomSource.XOR_SHIFT_1024_S_PHI.create();
         for (int i = 0; i < SEEDS; i++) {
             final long[] longArray = new long[MAX_SEED_SIZE];
             final int[] intArray = new int[MAX_SEED_SIZE];
@@ -841,8 +841,9 @@ public class ConstructionPerformance {
     @Benchmark
     public void createNullSeed(Sources sources, Blackhole bh) {
         final RandomSource randomSource = sources.getRandomSource();
+        final Object seed = null;
         for (int i = 0; i < SEEDS; i++) {
-            bh.consume(RandomSource.create(randomSource, null));
+            bh.consume(randomSource.create(seed));
         }
     }
 
@@ -855,7 +856,7 @@ public class ConstructionPerformance {
         final RandomSource randomSource = sources.getRandomSource();
         final Object[] nativeSeeds = sources.getNativeSeeds();
         for (int i = 0; i < SEEDS; i++) {
-            bh.consume(RandomSource.create(randomSource, nativeSeeds[i]));
+            bh.consume(randomSource.create(nativeSeeds[i]));
         }
     }
 
@@ -874,7 +875,7 @@ public class ConstructionPerformance {
         final RandomSource randomSource = sources.getRandomSource();
         final Object[] nativeSeeds1 = sources.getNativeSeeds1();
         for (int i = 0; i < SEEDS; i++) {
-            bh.consume(RandomSource.create(randomSource, nativeSeeds1[i]));
+            bh.consume(randomSource.create(nativeSeeds1[i]));
         }
     }
 
@@ -886,7 +887,7 @@ public class ConstructionPerformance {
     public void createLongSeed(Sources sources, Blackhole bh) {
         final RandomSource randomSource = sources.getRandomSource();
         for (int i = 0; i < SEEDS; i++) {
-            bh.consume(RandomSource.create(randomSource, LONG_SEEDS[i]));
+            bh.consume(randomSource.create(LONG_SEEDS[i]));
         }
     }
 
@@ -899,7 +900,7 @@ public class ConstructionPerformance {
         final RandomSource randomSource = sources.getRandomSource();
         final byte[][] byteSeeds = sources.getByteSeeds();
         for (int i = 0; i < SEEDS; i++) {
-            bh.consume(RandomSource.create(randomSource, byteSeeds[i]));
+            bh.consume(randomSource.create(byteSeeds[i]));
         }
     }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/SeedArrayGenerationPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/SeedArrayGenerationPerformance.java
@@ -102,7 +102,7 @@ public class SeedArrayGenerationPerformance {
          */
         @Setup
         public void setup() {
-            generator = RandomSource.create(RandomSource.valueOf(randomSourceName));
+            generator = RandomSource.valueOf(randomSourceName).create();
         }
     }
 

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/SeedGenerationPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/SeedGenerationPerformance.java
@@ -101,13 +101,13 @@ public class SeedGenerationPerformance {
     private final AtomicLong state = new AtomicLong();
 
     /** The XoRoShiRo128Plus RNG. */
-    private final UniformRandomProvider xoRoShiRo128Plus = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PLUS);
+    private final UniformRandomProvider xoRoShiRo128Plus = RandomSource.XO_RO_SHI_RO_128_PLUS.create();
 
     /** The XorShift1024StarPhi RNG. */
-    private final UniformRandomProvider xorShift1024StarPhi = RandomSource.create(RandomSource.XOR_SHIFT_1024_S_PHI);
+    private final UniformRandomProvider xorShift1024StarPhi = RandomSource.XOR_SHIFT_1024_S_PHI.create();
 
     /** The Well44497b RNG. */
-    private final UniformRandomProvider well44497b = RandomSource.create(RandomSource.WELL_44497_B);
+    private final UniformRandomProvider well44497b = RandomSource.WELL_44497_B.create();
 
     /** The JDK Random instance (the implementation is thread-safe). */
     private final Random random = new Random();

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/ThreadLocalPerformance.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/simple/ThreadLocalPerformance.java
@@ -106,7 +106,7 @@ public class ThreadLocalPerformance {
             rng = new ThreadLocal<UniformRandomProvider>() {
                 @Override
                 protected UniformRandomProvider initialValue() {
-                    return RandomSource.create(randomSource);
+                    return randomSource.create();
                 }
             };
         }
@@ -169,7 +169,7 @@ public class ThreadLocalPerformance {
     @Benchmark
     @Threads(4)
     public long randomSourceCreate(Sources sources) {
-        final UniformRandomProvider rng = RandomSource.create(sources.getRandomSource());
+        final UniformRandomProvider rng = sources.getRandomSource().create();
         long result = 0;
         for (int i = 0; i < numValues; i++) {
             result = result ^ rng.nextLong();

--- a/commons-rng-examples/examples-jpms/jpms-app/src/main/java/org/apache/commons/rng/examples/jpms/app/DiceGameApplication.java
+++ b/commons-rng-examples/examples-jpms/jpms-app/src/main/java/org/apache/commons/rng/examples/jpms/app/DiceGameApplication.java
@@ -43,7 +43,7 @@ public final class DiceGameApplication {
                                 int numRounds,
                                 RandomSource identifier) {
         game = new DiceGame(numPlayers, numRounds,
-                            RandomSource.create(identifier),
+                            identifier.create(),
                             4.3, 2.1);
     }
 

--- a/commons-rng-examples/examples-quadrature/src/main/java/org/apache/commons/rng/examples/quadrature/MonteCarloIntegration.java
+++ b/commons-rng-examples/examples-quadrature/src/main/java/org/apache/commons/rng/examples/quadrature/MonteCarloIntegration.java
@@ -38,7 +38,7 @@ public abstract class MonteCarloIntegration {
      */
     public MonteCarloIntegration(RandomSource source,
                                  int dimension) {
-        this.rng = RandomSource.create(source);
+        this.rng = source.create();
         this.dimension = dimension;
     }
 

--- a/commons-rng-examples/examples-sampling/src/main/java/org/apache/commons/rng/examples/sampling/ProbabilityDensityApproximationCommand.java
+++ b/commons-rng-examples/examples-sampling/src/main/java/org/apache/commons/rng/examples/sampling/ProbabilityDensityApproximationCommand.java
@@ -179,7 +179,7 @@ class ProbabilityDensityApproximationCommand  implements Callable<Void> {
             System.exit(1);
         }
 
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XOR_SHIFT_1024_S_PHI);
+        final UniformRandomProvider rng = RandomSource.XOR_SHIFT_1024_S_PHI.create();
 
         final double gaussMean = 1;
         final double gaussSigma = 2;

--- a/commons-rng-examples/examples-sampling/src/main/java/org/apache/commons/rng/examples/sampling/UniformSamplingVisualCheckCommand.java
+++ b/commons-rng-examples/examples-sampling/src/main/java/org/apache/commons/rng/examples/sampling/UniformSamplingVisualCheckCommand.java
@@ -61,7 +61,7 @@ class UniformSamplingVisualCheckCommand implements Callable<Void> {
     private int numSamples = 50;
 
     /** RNG. */
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.XOR_SHIFT_1024_S_PHI);
+    private final UniformRandomProvider rng = RandomSource.XOR_SHIFT_1024_S_PHI.create();
     /** Samplers. */
     private final ContinuousSampler[] samplers = new ContinuousSampler[] {
         ZigguratNormalizedGaussianSampler.of(rng),

--- a/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/OutputCommand.java
+++ b/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/OutputCommand.java
@@ -260,7 +260,7 @@ class OutputCommand implements Callable<Void> {
             data.add(RNGUtils.parseArgument(argument));
         }
         try {
-            return RandomSource.create(randomSource, objectSeed, data.toArray());
+            return randomSource.create(objectSeed, data.toArray());
         } catch (IllegalStateException | IllegalArgumentException ex) {
             throw new ApplicationException("Failed to create RNG: " + randomSource + ". " + ex.getMessage(), ex);
         }

--- a/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/StressTestCommand.java
+++ b/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/StressTestCommand.java
@@ -519,7 +519,7 @@ class StressTestCommand implements Callable<Void> {
                 }
                 if (xorRandomSource != null) {
                     rng = RNGUtils.createXorProvider(
-                            RandomSource.create(xorRandomSource),
+                            xorRandomSource.create(),
                             rng);
                 }
                 if (reverseBits) {

--- a/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/StressTestData.java
+++ b/commons-rng-examples/examples-stress/src/main/java/org/apache/commons/rng/examples/stress/StressTestData.java
@@ -103,7 +103,7 @@ class StressTestData {
      * @return the uniform random provider
      */
     UniformRandomProvider createRNG(byte[] seed) {
-        return RandomSource.create(randomSource, seed, args);
+        return randomSource.create(seed, args);
     }
 
     /**

--- a/commons-rng-examples/examples-stress/src/test/java/org/apache/commons/rng/examples/stress/RngDataOutputTest.java
+++ b/commons-rng-examples/examples-stress/src/test/java/org/apache/commons/rng/examples/stress/RngDataOutputTest.java
@@ -151,8 +151,8 @@ public class RngDataOutputTest {
         RngDataOutputFactory factory,
         ByteOrder byteOrder) throws IOException {
         final long seed = RandomSource.createLong();
-        UniformRandomProvider rng1 = RandomSource.create(source, seed);
-        UniformRandomProvider rng2 = RandomSource.create(source, seed);
+        UniformRandomProvider rng1 = source.create(seed);
+        UniformRandomProvider rng2 = source.create(seed);
         final int size = 37;
         for (int repeats = 1; repeats <= 2; repeats++) {
             byte[] expected = createBytes(rng1, size, repeats, rngConverter, pipe);

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSampler.java
@@ -42,7 +42,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * final RealDistribution dist = new ChiSquaredDistribution(9);
  * // Create the sampler.
  * final ContinuousSampler chiSquareSampler =
- *     InverseTransformContinuousSampler.of(RandomSource.create(RandomSource.MT),
+ *     InverseTransformContinuousSampler.of(RandomSource.MT.create(),
  *                                          new ContinuousInverseCumulativeProbabilityFunction() {
  *                                              public double inverseCumulativeProbability(double p) {
  *                                                  return dist.inverseCumulativeProbability(p);

--- a/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSampler.java
+++ b/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSampler.java
@@ -42,7 +42,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * final IntegerDistribution dist = new BinomialDistribution(11, 0.56);
  * // Create the sampler.
  * final DiscreteSampler binomialSampler =
- *     InverseTransformDiscreteSampler.of(RandomSource.create(RandomSource.MT),
+ *     InverseTransformDiscreteSampler.of(RandomSource.MT.create(),
  *                                        new DiscreteInverseCumulativeProbabilityFunction() {
  *                                            public int inverseCumulativeProbability(double p) {
  *                                                return dist.inverseCumulativeProbability(p);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CollectionSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CollectionSamplerTest.java
@@ -38,7 +38,7 @@ public class CollectionSamplerTest {
         list.add("RNG");
 
         final CollectionSampler<String> sampler =
-            new CollectionSampler<String>(RandomSource.create(RandomSource.MWC_256),
+            new CollectionSampler<String>(RandomSource.MWC_256.create(),
                                           list);
         final String word = sampler.sample();
         for (String w : list) {
@@ -52,7 +52,7 @@ public class CollectionSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testSamplePrecondition() {
         // Must fail for empty collection.
-        new CollectionSampler<String>(RandomSource.create(RandomSource.MT),
+        new CollectionSampler<String>(RandomSource.SPLIT_MIX_64.create(0L),
                                       new ArrayList<String>());
     }
 
@@ -61,8 +61,8 @@ public class CollectionSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final List<String> list = Arrays.asList("Apache", "Commons", "RNG");
         final CollectionSampler<String> sampler1 =
             new CollectionSampler<String>(rng1, list);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CombinationSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/CombinationSamplerTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.rng.simple.RandomSource;
  * Tests for {@link CombinationSampler}.
  */
 public class CombinationSamplerTest {
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.XOR_SHIFT_1024_S);
+    private final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
 
     @Test
     public void testSampleIsInDomain() {
@@ -118,8 +118,8 @@ public class CombinationSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final int n = 17;
         final int k = 3;
         final CombinationSampler sampler1 =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/DiscreteProbabilityCollectionSamplerTest.java
@@ -34,7 +34,7 @@ import org.apache.commons.rng.simple.RandomSource;
  */
 public class DiscreteProbabilityCollectionSamplerTest {
     /** RNG. */
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.WELL_1024_A);
+    private final UniformRandomProvider rng = RandomSource.XO_SHI_RO_128_PP.create();
 
     @Test(expected = IllegalArgumentException.class)
     public void testPrecondition1() {
@@ -112,8 +112,8 @@ public class DiscreteProbabilityCollectionSamplerTest {
 
     @Test
     public void testSampleUsingMap() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final List<Integer> items = Arrays.asList(1, 3, 4, 6, 9);
         final double[] probabilities = {0.1, 0.2, 0.3, 0.4, 0.5};
         final DiscreteProbabilityCollectionSampler<Integer> sampler1 =
@@ -176,8 +176,8 @@ public class DiscreteProbabilityCollectionSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final List<Double> items = Arrays.asList(new Double[] {1d, 2d, 3d, 4d});
         final DiscreteProbabilityCollectionSampler<Double> sampler1 =
             new DiscreteProbabilityCollectionSampler<Double>(rng1,

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/ListSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/ListSamplerTest.java
@@ -36,7 +36,7 @@ import org.apache.commons.rng.simple.RandomSource;
  * Tests for {@link ListSampler}.
  */
 public class ListSamplerTest {
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.ISAAC, 6543432321L);
+    private final UniformRandomProvider rng = RandomSource.ISAAC.create(6543432321L);
     private final ChiSquareTest chiSquareTest = new ChiSquareTest();
 
     @Test
@@ -259,8 +259,8 @@ public class ListSamplerTest {
 
         // Identical RNGs
         final long seed = RandomSource.createLong();
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(seed);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(seed);
 
         ListSampler.shuffle(rng1, list);
         PermutationSampler.shuffle(rng2, array);
@@ -291,8 +291,8 @@ public class ListSamplerTest {
 
         // Identical RNGs
         final long seed = RandomSource.createLong();
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(seed);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(seed);
 
         ListSampler.shuffle(rng1, list, start, towardHead);
         PermutationSampler.shuffle(rng2, array, start, towardHead);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/PermutationSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/PermutationSamplerTest.java
@@ -30,14 +30,14 @@ import org.apache.commons.rng.simple.RandomSource;
  * Tests for {@link PermutationSampler}.
  */
 public class PermutationSamplerTest {
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.ISAAC, 1232343456L);
+    private final UniformRandomProvider rng = RandomSource.ISAAC.create(1232343456L);
     private final ChiSquareTest chiSquareTest = new ChiSquareTest();
 
     @Test
     public void testSampleTrivial() {
         final int n = 6;
         final int k = 3;
-        final PermutationSampler sampler = new PermutationSampler(RandomSource.create(RandomSource.KISS),
+        final PermutationSampler sampler = new PermutationSampler(RandomSource.KISS.create(),
                                                                   n, k);
         final int[] random = sampler.sample();
         SAMPLE: for (int s : random) {
@@ -191,8 +191,8 @@ public class PermutationSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final int n = 17;
         final int k = 13;
         final PermutationSampler sampler1 =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/UnitSphereSamplerTest.java
@@ -68,7 +68,7 @@ public class UnitSphereSamplerTest {
      * RNG-130: All samples should be 1 or -1.
      */
     private static void testDistribution1D(boolean factoryConstructor) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, 0x1a2b3cL);
+        final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create(0x1a2b3cL);
         final UnitSphereSampler generator = createUnitSphereSampler(1, rng, factoryConstructor);
         final int samples = 10000;
         // Count the negatives.
@@ -140,7 +140,7 @@ public class UnitSphereSamplerTest {
      * Obtains polar coordinates and checks the angle distribution is uniform.
      */
     private static void testDistribution2D(boolean factoryConstructor) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XOR_SHIFT_1024_S, 17399225432L);
+        final UniformRandomProvider rng = RandomSource.XOR_SHIFT_1024_S_PHI.create(17399225432L);
         final UnitSphereSampler generator = createUnitSphereSampler(2, rng, factoryConstructor);
 
         // In 2D, angles with a given vector should be uniformly distributed.
@@ -183,7 +183,7 @@ public class UnitSphereSamplerTest {
      * Obtains spherical coordinates and checks the distribution is uniform.
      */
     private static void testDistribution3D(boolean factoryConstructor) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_256_PP, 0xabcdefL);
+        final UniformRandomProvider rng = RandomSource.XO_SHI_RO_256_PP.create(0xabcdefL);
         final UnitSphereSampler generator = createUnitSphereSampler(3, rng, factoryConstructor);
 
         // Get 3D spherical coordinates. Assign to a bin.
@@ -235,7 +235,7 @@ public class UnitSphereSamplerTest {
      * Checks the surface of the 3-sphere can be used to generate uniform samples within a circle.
      */
     private static void testDistribution4D(boolean factoryConstructor) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_512_PP, 0x9876543210L);
+        final UniformRandomProvider rng = RandomSource.XO_SHI_RO_512_PP.create(0x9876543210L);
         final UnitSphereSampler generator = createUnitSphereSampler(4, rng, factoryConstructor);
 
         // No uniform distribution of spherical coordinates for a 3-sphere.
@@ -520,8 +520,8 @@ public class UnitSphereSamplerTest {
      * @param factoryConstructor true to use the factory constructor
      */
     private static void testSharedStateSampler(int dimension, boolean factoryConstructor) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final UnitSphereSampler sampler1 = createUnitSphereSampler(dimension, rng1, factoryConstructor);
         final UnitSphereSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterExponentialSamplerTest.java
@@ -32,7 +32,7 @@ public class AhrensDieterExponentialSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroMean() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 0;
         AhrensDieterExponentialSampler.of(rng, mean);
     }
@@ -42,8 +42,8 @@ public class AhrensDieterExponentialSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 1.23;
         final SharedStateContinuousSampler sampler1 =
             AhrensDieterExponentialSampler.of(rng1, mean);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AhrensDieterMarsagliaTsangGammaSamplerTest.java
@@ -33,7 +33,7 @@ public class AhrensDieterMarsagliaTsangGammaSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroAlpha() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double alpha = 0;
         final double theta = 1;
         AhrensDieterMarsagliaTsangGammaSampler.of(rng, alpha, theta);
@@ -45,7 +45,7 @@ public class AhrensDieterMarsagliaTsangGammaSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroTheta() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double alpha = 1;
         final double theta = 0;
         AhrensDieterMarsagliaTsangGammaSampler.of(rng, alpha, theta);
@@ -74,8 +74,8 @@ public class AhrensDieterMarsagliaTsangGammaSamplerTest {
      * @param theta Theta.
      */
     private static void testSharedStateSampler(double alpha, double theta) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         // Use instance constructor not factory constructor to exercise 1.X public API
         final AhrensDieterMarsagliaTsangGammaSampler sampler1 =
             new AhrensDieterMarsagliaTsangGammaSampler(rng1, alpha, theta);
@@ -89,7 +89,7 @@ public class AhrensDieterMarsagliaTsangGammaSamplerTest {
      */
     @Test
     public void testToString() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         Assert.assertTrue(new AhrensDieterMarsagliaTsangGammaSampler(rng, 1.0, 2.0).toString()
                 .toLowerCase().contains("gamma"));
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/AliasMethodDiscreteSamplerTest.java
@@ -79,7 +79,7 @@ public class AliasMethodDiscreteSamplerTest {
      * @return the alias method discrete sampler
      */
     private static SharedStateDiscreteSampler createSampler(double[] probabilities) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
         return AliasMethodDiscreteSampler.of(rng, probabilities, -1);
     }
 
@@ -130,7 +130,7 @@ public class AliasMethodDiscreteSamplerTest {
     @Test
     public void testNonUniformSamplesWithProbabilitiesWithDefaultFactoryConstructor() {
         final double[] expected = {0.1, 0.2, 0.3, 0.1, 0.3 };
-        checkSamples(AliasMethodDiscreteSampler.of(RandomSource.create(RandomSource.SPLIT_MIX_64), expected), expected);
+        checkSamples(AliasMethodDiscreteSampler.of(RandomSource.SPLIT_MIX_64.create(), expected), expected);
     }
 
     /**
@@ -272,8 +272,8 @@ public class AliasMethodDiscreteSamplerTest {
      * @param probabilities The probabilities
      */
     private static void testSharedStateSampler(double[] probabilities) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         // Use negative alpha to disable padding
         final SharedStateDiscreteSampler sampler1 =
             AliasMethodDiscreteSampler.of(rng1, probabilities, -1);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerGaussianSamplerTest.java
@@ -30,10 +30,10 @@ public class BoxMullerGaussianSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroStandardDeviation() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 1;
         final double standardDeviation = 0;
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "deprecation"})
         final BoxMullerGaussianSampler sampler =
             new BoxMullerGaussianSampler(rng, mean, standardDeviation);
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerLogNormalSamplerTest.java
@@ -30,10 +30,10 @@ public class BoxMullerLogNormalSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithNegativeScale() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double scale = -1e-6;
         final double shape = 1;
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "deprecation"})
         final BoxMullerLogNormalSampler sampler =
             new BoxMullerLogNormalSampler(rng, scale, shape);
     }
@@ -44,10 +44,10 @@ public class BoxMullerLogNormalSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double scale = 1;
         final double shape = 0;
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "deprecation"})
         final BoxMullerLogNormalSampler sampler =
             new BoxMullerLogNormalSampler(rng, scale, shape);
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalisedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/BoxMullerNormalisedGaussianSamplerTest.java
@@ -30,8 +30,8 @@ public class BoxMullerNormalisedGaussianSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateContinuousSampler sampler1 =
             BoxMullerNormalizedGaussianSampler.<BoxMullerNormalizedGaussianSampler>of(rng1);
         final SharedStateContinuousSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ChengBetaSamplerTest.java
@@ -33,7 +33,7 @@ public class ChengBetaSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroAlpha() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double alpha = 0;
         final double beta = 1;
         ChengBetaSampler.of(rng, alpha, beta);
@@ -45,7 +45,7 @@ public class ChengBetaSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroBeta() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double alpha = 1;
         final double beta = 0;
         ChengBetaSampler.of(rng, alpha, beta);
@@ -90,8 +90,8 @@ public class ChengBetaSamplerTest {
      * @param beta Beta.
      */
     private static void testSharedStateSampler(double alpha, double beta) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         // Use instance constructor not factory constructor to exercise 1.X public API
         final SharedStateContinuousSampler sampler1 =
             new ChengBetaSampler(rng1, alpha, beta);
@@ -105,7 +105,7 @@ public class ChengBetaSamplerTest {
      */
     @Test
     public void testToString() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         Assert.assertTrue(new ChengBetaSampler(rng, 1.0, 2.0).toString()
                 .toLowerCase().contains("beta"));
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousSamplersList.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousSamplersList.java
@@ -46,168 +46,168 @@ public final class ContinuousSamplersList {
             final double meanNormal = -123.45;
             final double sigmaNormal = 6.789;
             add(LIST, new org.apache.commons.math3.distribution.NormalDistribution(unusedRng, meanNormal, sigmaNormal),
-                RandomSource.create(RandomSource.KISS));
+                RandomSource.KISS.create());
             // Gaussian (DEPRECATED "Box-Muller").
             add(LIST, new org.apache.commons.math3.distribution.NormalDistribution(unusedRng, meanNormal, sigmaNormal),
-                new BoxMullerGaussianSampler(RandomSource.create(RandomSource.MT), meanNormal, sigmaNormal));
+                new BoxMullerGaussianSampler(RandomSource.MT.create(), meanNormal, sigmaNormal));
             // Gaussian ("Box-Muller").
             add(LIST, new org.apache.commons.math3.distribution.NormalDistribution(unusedRng, meanNormal, sigmaNormal),
-                GaussianSampler.of(new BoxMullerNormalizedGaussianSampler(RandomSource.create(RandomSource.MT)),
+                GaussianSampler.of(new BoxMullerNormalizedGaussianSampler(RandomSource.MT.create()),
                                    meanNormal, sigmaNormal));
             // Gaussian ("Marsaglia").
             add(LIST, new org.apache.commons.math3.distribution.NormalDistribution(unusedRng, meanNormal, sigmaNormal),
-                GaussianSampler.of(new MarsagliaNormalizedGaussianSampler(RandomSource.create(RandomSource.MT)),
+                GaussianSampler.of(new MarsagliaNormalizedGaussianSampler(RandomSource.MT.create()),
                                    meanNormal, sigmaNormal));
             // Gaussian ("Ziggurat").
             add(LIST, new org.apache.commons.math3.distribution.NormalDistribution(unusedRng, meanNormal, sigmaNormal),
-                GaussianSampler.of(new ZigguratNormalizedGaussianSampler(RandomSource.create(RandomSource.MT)),
+                GaussianSampler.of(new ZigguratNormalizedGaussianSampler(RandomSource.MT.create()),
                                    meanNormal, sigmaNormal));
 
             // Beta ("inverse method").
             final double alphaBeta = 4.3;
             final double betaBeta = 2.1;
             add(LIST, new org.apache.commons.math3.distribution.BetaDistribution(unusedRng, alphaBeta, betaBeta),
-                RandomSource.create(RandomSource.ISAAC));
+                RandomSource.ISAAC.create());
             // Beta ("Cheng").
             add(LIST, new org.apache.commons.math3.distribution.BetaDistribution(unusedRng, alphaBeta, betaBeta),
-                ChengBetaSampler.of(RandomSource.create(RandomSource.MWC_256), alphaBeta, betaBeta));
+                ChengBetaSampler.of(RandomSource.MWC_256.create(), alphaBeta, betaBeta));
             add(LIST, new org.apache.commons.math3.distribution.BetaDistribution(unusedRng, betaBeta, alphaBeta),
-                ChengBetaSampler.of(RandomSource.create(RandomSource.WELL_19937_A), betaBeta, alphaBeta));
+                ChengBetaSampler.of(RandomSource.WELL_19937_A.create(), betaBeta, alphaBeta));
             // Beta ("Cheng", alternate algorithm).
             final double alphaBetaAlt = 0.5678;
             final double betaBetaAlt = 0.1234;
             add(LIST, new org.apache.commons.math3.distribution.BetaDistribution(unusedRng, alphaBetaAlt, betaBetaAlt),
-                ChengBetaSampler.of(RandomSource.create(RandomSource.WELL_512_A), alphaBetaAlt, betaBetaAlt));
+                ChengBetaSampler.of(RandomSource.WELL_512_A.create(), alphaBetaAlt, betaBetaAlt));
             add(LIST, new org.apache.commons.math3.distribution.BetaDistribution(unusedRng, betaBetaAlt, alphaBetaAlt),
-                ChengBetaSampler.of(RandomSource.create(RandomSource.WELL_19937_C), betaBetaAlt, alphaBetaAlt));
+                ChengBetaSampler.of(RandomSource.WELL_19937_C.create(), betaBetaAlt, alphaBetaAlt));
 
             // Cauchy ("inverse method").
             final double medianCauchy = 0.123;
             final double scaleCauchy = 4.5;
             add(LIST, new org.apache.commons.math3.distribution.CauchyDistribution(unusedRng, medianCauchy, scaleCauchy),
-                RandomSource.create(RandomSource.WELL_19937_C));
+                RandomSource.WELL_19937_C.create());
 
             // Chi-square ("inverse method").
             final int dofChi2 = 12;
             add(LIST, new org.apache.commons.math3.distribution.ChiSquaredDistribution(unusedRng, dofChi2),
-                RandomSource.create(RandomSource.WELL_19937_A));
+                RandomSource.WELL_19937_A.create());
 
             // Exponential ("inverse method").
             final double meanExp = 3.45;
             add(LIST, new org.apache.commons.math3.distribution.ExponentialDistribution(unusedRng, meanExp),
-                RandomSource.create(RandomSource.WELL_44497_A));
+                RandomSource.WELL_44497_A.create());
             // Exponential.
             add(LIST, new org.apache.commons.math3.distribution.ExponentialDistribution(unusedRng, meanExp),
-                AhrensDieterExponentialSampler.of(RandomSource.create(RandomSource.MT), meanExp));
+                AhrensDieterExponentialSampler.of(RandomSource.MT.create(), meanExp));
 
             // F ("inverse method").
             final int numDofF = 4;
             final int denomDofF = 7;
             add(LIST, new org.apache.commons.math3.distribution.FDistribution(unusedRng, numDofF, denomDofF),
-                RandomSource.create(RandomSource.MT_64));
+                RandomSource.MT_64.create());
 
             // Gamma ("inverse method").
             final double alphaGammaSmallerThanOne = 0.1234;
             final double alphaGammaLargerThanOne = 2.345;
             final double thetaGamma = 3.456;
             add(LIST, new org.apache.commons.math3.distribution.GammaDistribution(unusedRng, alphaGammaLargerThanOne, thetaGamma),
-                RandomSource.create(RandomSource.SPLIT_MIX_64));
+                RandomSource.SPLIT_MIX_64.create());
             // Gamma (alpha < 1).
             add(LIST, new org.apache.commons.math3.distribution.GammaDistribution(unusedRng, alphaGammaSmallerThanOne, thetaGamma),
-                AhrensDieterMarsagliaTsangGammaSampler.of(RandomSource.create(RandomSource.XOR_SHIFT_1024_S),
+                AhrensDieterMarsagliaTsangGammaSampler.of(RandomSource.XOR_SHIFT_1024_S_PHI.create(),
                                                           alphaGammaSmallerThanOne, thetaGamma));
             // Gamma (alpha > 1).
             add(LIST, new org.apache.commons.math3.distribution.GammaDistribution(unusedRng, alphaGammaLargerThanOne, thetaGamma),
-                AhrensDieterMarsagliaTsangGammaSampler.of(RandomSource.create(RandomSource.WELL_44497_B),
+                AhrensDieterMarsagliaTsangGammaSampler.of(RandomSource.WELL_44497_B.create(),
                                                           alphaGammaLargerThanOne, thetaGamma));
 
             // Gumbel ("inverse method").
             final double muGumbel = -4.56;
             final double betaGumbel = 0.123;
             add(LIST, new org.apache.commons.math3.distribution.GumbelDistribution(unusedRng, muGumbel, betaGumbel),
-                RandomSource.create(RandomSource.WELL_1024_A));
+                RandomSource.WELL_1024_A.create());
 
             // Laplace ("inverse method").
             final double muLaplace = 12.3;
             final double betaLaplace = 5.6;
             add(LIST, new org.apache.commons.math3.distribution.LaplaceDistribution(unusedRng, muLaplace, betaLaplace),
-                RandomSource.create(RandomSource.MWC_256));
+                RandomSource.MWC_256.create());
 
             // Levy ("inverse method").
             final double muLevy = -1.098;
             final double cLevy = 0.76;
             add(LIST, new org.apache.commons.math3.distribution.LevyDistribution(unusedRng, muLevy, cLevy),
-                RandomSource.create(RandomSource.TWO_CMRES));
+                RandomSource.TWO_CMRES.create());
 
             // Log normal ("inverse method").
             final double scaleLogNormal = 2.345;
             final double shapeLogNormal = 0.1234;
             add(LIST, new org.apache.commons.math3.distribution.LogNormalDistribution(unusedRng, scaleLogNormal, shapeLogNormal),
-                RandomSource.create(RandomSource.KISS));
+                RandomSource.KISS.create());
             // Log-normal (DEPRECATED "Box-Muller").
             add(LIST, new org.apache.commons.math3.distribution.LogNormalDistribution(unusedRng, scaleLogNormal, shapeLogNormal),
-                new BoxMullerLogNormalSampler(RandomSource.create(RandomSource.XOR_SHIFT_1024_S), scaleLogNormal, shapeLogNormal));
+                new BoxMullerLogNormalSampler(RandomSource.XOR_SHIFT_1024_S_PHI.create(), scaleLogNormal, shapeLogNormal));
             // Log-normal ("Box-Muller").
             add(LIST, new org.apache.commons.math3.distribution.LogNormalDistribution(unusedRng, scaleLogNormal, shapeLogNormal),
-                LogNormalSampler.of(new BoxMullerNormalizedGaussianSampler(RandomSource.create(RandomSource.XOR_SHIFT_1024_S)),
+                LogNormalSampler.of(new BoxMullerNormalizedGaussianSampler(RandomSource.XOR_SHIFT_1024_S_PHI.create()),
                                     scaleLogNormal, shapeLogNormal));
             // Log-normal ("Marsaglia").
             add(LIST, new org.apache.commons.math3.distribution.LogNormalDistribution(unusedRng, scaleLogNormal, shapeLogNormal),
-                LogNormalSampler.of(new MarsagliaNormalizedGaussianSampler(RandomSource.create(RandomSource.MT_64)),
+                LogNormalSampler.of(new MarsagliaNormalizedGaussianSampler(RandomSource.MT_64.create()),
                                     scaleLogNormal, shapeLogNormal));
             // Log-normal ("Ziggurat").
             add(LIST, new org.apache.commons.math3.distribution.LogNormalDistribution(unusedRng, scaleLogNormal, shapeLogNormal),
-                LogNormalSampler.of(new ZigguratNormalizedGaussianSampler(RandomSource.create(RandomSource.MWC_256)),
+                LogNormalSampler.of(new ZigguratNormalizedGaussianSampler(RandomSource.MWC_256.create()),
                                     scaleLogNormal, shapeLogNormal));
 
             // Logistic ("inverse method").
             final double muLogistic = -123.456;
             final double sLogistic = 7.89;
             add(LIST, new org.apache.commons.math3.distribution.LogisticDistribution(unusedRng, muLogistic, sLogistic),
-                RandomSource.create(RandomSource.TWO_CMRES_SELECT, null, 2, 6));
+                RandomSource.TWO_CMRES_SELECT.create((Object) null, 2, 6));
 
             // Nakagami ("inverse method").
             final double muNakagami = 78.9;
             final double omegaNakagami = 23.4;
             final double inverseAbsoluteAccuracyNakagami = org.apache.commons.math3.distribution.NakagamiDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY;
             add(LIST, new org.apache.commons.math3.distribution.NakagamiDistribution(unusedRng, muNakagami, omegaNakagami, inverseAbsoluteAccuracyNakagami),
-                RandomSource.create(RandomSource.TWO_CMRES_SELECT, null, 5, 3));
+                RandomSource.TWO_CMRES_SELECT.create((Object) null, 5, 3));
 
             // Pareto ("inverse method").
             final double scalePareto = 23.45;
             final double shapePareto = 0.1234;
             add(LIST, new org.apache.commons.math3.distribution.ParetoDistribution(unusedRng, scalePareto, shapePareto),
-                RandomSource.create(RandomSource.TWO_CMRES_SELECT, null, 9, 11));
+                RandomSource.TWO_CMRES_SELECT.create((Object) null, 9, 11));
             // Pareto.
             add(LIST, new org.apache.commons.math3.distribution.ParetoDistribution(unusedRng, scalePareto, shapePareto),
-                InverseTransformParetoSampler.of(RandomSource.create(RandomSource.XOR_SHIFT_1024_S), scalePareto, shapePareto));
+                InverseTransformParetoSampler.of(RandomSource.XOR_SHIFT_1024_S_PHI.create(), scalePareto, shapePareto));
 
             // T ("inverse method").
             final double dofT = 0.76543;
             add(LIST, new org.apache.commons.math3.distribution.TDistribution(unusedRng, dofT),
-                RandomSource.create(RandomSource.ISAAC));
+                RandomSource.ISAAC.create());
 
             // Triangular ("inverse method").
             final double aTriangle = -0.76543;
             final double cTriangle = -0.65432;
             final double bTriangle = -0.54321;
             add(LIST, new org.apache.commons.math3.distribution.TriangularDistribution(unusedRng, aTriangle, cTriangle, bTriangle),
-                RandomSource.create(RandomSource.MT));
+                RandomSource.MT.create());
 
             // Uniform ("inverse method").
             final double loUniform = -1.098;
             final double hiUniform = 0.76;
             add(LIST, new org.apache.commons.math3.distribution.UniformRealDistribution(unusedRng, loUniform, hiUniform),
-                RandomSource.create(RandomSource.TWO_CMRES));
+                RandomSource.TWO_CMRES.create());
             // Uniform.
             add(LIST, new org.apache.commons.math3.distribution.UniformRealDistribution(unusedRng, loUniform, hiUniform),
-                ContinuousUniformSampler.of(RandomSource.create(RandomSource.MT_64), loUniform, hiUniform));
+                ContinuousUniformSampler.of(RandomSource.MT_64.create(), loUniform, hiUniform));
 
             // Weibull ("inverse method").
             final double alphaWeibull = 678.9;
             final double betaWeibull = 98.76;
             add(LIST, new org.apache.commons.math3.distribution.WeibullDistribution(unusedRng, alphaWeibull, betaWeibull),
-                RandomSource.create(RandomSource.WELL_44497_B));
+                RandomSource.WELL_44497_B.create());
         } catch (Exception e) {
             // CHECKSTYLE: stop Regexp
             System.err.println("Unexpected exception while creating the list of samplers: " + e);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ContinuousUniformSamplerTest.java
@@ -33,7 +33,7 @@ public class ContinuousUniformSamplerTest {
     public void testNoRestrictionOnOrderOfLowAndHighParameters() {
         final double low = 3.18;
         final double high = 5.23;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
         testSampleInRange(rng, low, high);
         testSampleInRange(rng, high, low);
     }
@@ -54,8 +54,8 @@ public class ContinuousUniformSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double low = 1.23;
         final double high = 4.56;
         final SharedStateContinuousSampler sampler1 =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteSamplersList.java
@@ -49,26 +49,26 @@ public final class DiscreteSamplersList {
             final double probSuccessBinomial = 0.67;
             add(LIST, new org.apache.commons.math3.distribution.BinomialDistribution(unusedRng, trialsBinomial, probSuccessBinomial),
                 MathArrays.sequence(8, 9, 1),
-                RandomSource.create(RandomSource.KISS));
+                RandomSource.KISS.create());
             add(LIST, new org.apache.commons.math3.distribution.BinomialDistribution(unusedRng, trialsBinomial, probSuccessBinomial),
                 // range [9,16]
                 MathArrays.sequence(8, 9, 1),
-                MarsagliaTsangWangDiscreteSampler.Binomial.of(RandomSource.create(RandomSource.WELL_19937_A), trialsBinomial, probSuccessBinomial));
+                MarsagliaTsangWangDiscreteSampler.Binomial.of(RandomSource.WELL_19937_A.create(), trialsBinomial, probSuccessBinomial));
             // Inverted
             add(LIST, new org.apache.commons.math3.distribution.BinomialDistribution(unusedRng, trialsBinomial, 1 - probSuccessBinomial),
                 // range [4,11] = [20-16, 20-9]
                 MathArrays.sequence(8, 4, 1),
-                MarsagliaTsangWangDiscreteSampler.Binomial.of(RandomSource.create(RandomSource.WELL_19937_C), trialsBinomial, 1 - probSuccessBinomial));
+                MarsagliaTsangWangDiscreteSampler.Binomial.of(RandomSource.WELL_19937_C.create(), trialsBinomial, 1 - probSuccessBinomial));
 
             // Geometric ("inverse method").
             final double probSuccessGeometric = 0.21;
             add(LIST, new org.apache.commons.math3.distribution.GeometricDistribution(unusedRng, probSuccessGeometric),
                 MathArrays.sequence(10, 0, 1),
-                RandomSource.create(RandomSource.ISAAC));
+                RandomSource.ISAAC.create());
             // Geometric.
             add(LIST, new org.apache.commons.math3.distribution.GeometricDistribution(unusedRng, probSuccessGeometric),
                 MathArrays.sequence(10, 0, 1),
-                GeometricSampler.of(RandomSource.create(RandomSource.XOR_SHIFT_1024_S), probSuccessGeometric));
+                GeometricSampler.of(RandomSource.XOR_SHIFT_1024_S_PHI.create(), probSuccessGeometric));
 
             // Hypergeometric ("inverse method").
             final int popSizeHyper = 34;
@@ -76,54 +76,54 @@ public final class DiscreteSamplersList {
             final int sampleSizeHyper = 12;
             add(LIST, new org.apache.commons.math3.distribution.HypergeometricDistribution(unusedRng, popSizeHyper, numSuccessesHyper, sampleSizeHyper),
                 MathArrays.sequence(10, 0, 1),
-                RandomSource.create(RandomSource.MT));
+                RandomSource.MT.create());
 
             // Pascal ("inverse method").
             final int numSuccessesPascal = 6;
             final double probSuccessPascal = 0.2;
             add(LIST, new org.apache.commons.math3.distribution.PascalDistribution(unusedRng, numSuccessesPascal, probSuccessPascal),
                 MathArrays.sequence(18, 1, 1),
-                RandomSource.create(RandomSource.TWO_CMRES));
+                RandomSource.TWO_CMRES.create());
 
             // Uniform ("inverse method").
             final int loUniform = -3;
             final int hiUniform = 4;
             add(LIST, new org.apache.commons.math3.distribution.UniformIntegerDistribution(unusedRng, loUniform, hiUniform),
                 MathArrays.sequence(8, -3, 1),
-                RandomSource.create(RandomSource.SPLIT_MIX_64));
+                RandomSource.SPLIT_MIX_64.create());
             // Uniform (power of 2 range).
             add(LIST, new org.apache.commons.math3.distribution.UniformIntegerDistribution(unusedRng, loUniform, hiUniform),
                 MathArrays.sequence(8, -3, 1),
-                DiscreteUniformSampler.of(RandomSource.create(RandomSource.MT_64), loUniform, hiUniform));
+                DiscreteUniformSampler.of(RandomSource.MT_64.create(), loUniform, hiUniform));
             // Uniform (large range).
             final int halfMax = Integer.MAX_VALUE / 2;
             final int hiLargeUniform = halfMax + 10;
             final int loLargeUniform = -hiLargeUniform;
             add(LIST, new org.apache.commons.math3.distribution.UniformIntegerDistribution(unusedRng, loLargeUniform, hiLargeUniform),
                 MathArrays.sequence(20, -halfMax, halfMax / 10),
-                DiscreteUniformSampler.of(RandomSource.create(RandomSource.WELL_1024_A), loLargeUniform, hiLargeUniform));
+                DiscreteUniformSampler.of(RandomSource.WELL_1024_A.create(), loLargeUniform, hiLargeUniform));
             // Uniform (non-power of 2 range).
             final int rangeNonPowerOf2Uniform = 11;
             final int hiNonPowerOf2Uniform = loUniform + rangeNonPowerOf2Uniform;
             add(LIST, new org.apache.commons.math3.distribution.UniformIntegerDistribution(unusedRng, loUniform, hiNonPowerOf2Uniform),
                 MathArrays.sequence(rangeNonPowerOf2Uniform, -3, 1),
-                DiscreteUniformSampler.of(RandomSource.create(RandomSource.XO_SHI_RO_256_SS), loUniform, hiNonPowerOf2Uniform));
+                DiscreteUniformSampler.of(RandomSource.XO_SHI_RO_256_SS.create(), loUniform, hiNonPowerOf2Uniform));
 
             // Zipf ("inverse method").
             final int numElementsZipf = 5;
             final double exponentZipf = 2.345;
             add(LIST, new org.apache.commons.math3.distribution.ZipfDistribution(unusedRng, numElementsZipf, exponentZipf),
                 MathArrays.sequence(5, 1, 1),
-                RandomSource.create(RandomSource.XOR_SHIFT_1024_S));
+                RandomSource.XOR_SHIFT_1024_S_PHI.create());
             // Zipf.
             add(LIST, new org.apache.commons.math3.distribution.ZipfDistribution(unusedRng, numElementsZipf, exponentZipf),
                 MathArrays.sequence(5, 1, 1),
-                RejectionInversionZipfSampler.of(RandomSource.create(RandomSource.WELL_19937_C), numElementsZipf, exponentZipf));
+                RejectionInversionZipfSampler.of(RandomSource.WELL_19937_C.create(), numElementsZipf, exponentZipf));
             // Zipf (exponent close to 1).
             final double exponentCloseToOneZipf = 1 - 1e-10;
             add(LIST, new org.apache.commons.math3.distribution.ZipfDistribution(unusedRng, numElementsZipf, exponentCloseToOneZipf),
                 MathArrays.sequence(5, 1, 1),
-                RejectionInversionZipfSampler.of(RandomSource.create(RandomSource.WELL_19937_C), numElementsZipf, exponentCloseToOneZipf));
+                RejectionInversionZipfSampler.of(RandomSource.WELL_19937_C.create(), numElementsZipf, exponentCloseToOneZipf));
 
             // Poisson ("inverse method").
             final double epsilonPoisson = org.apache.commons.math3.distribution.PoissonDistribution.DEFAULT_EPSILON;
@@ -131,59 +131,59 @@ public final class DiscreteSamplersList {
             final double meanPoisson = 3.21;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                RandomSource.create(RandomSource.MWC_256));
+                RandomSource.MWC_256.create());
             // Poisson.
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                PoissonSampler.of(RandomSource.create(RandomSource.KISS), meanPoisson));
+                PoissonSampler.of(RandomSource.KISS.create(), meanPoisson));
             // Dedicated small mean poisson samplers
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                SmallMeanPoissonSampler.of(RandomSource.create(RandomSource.XO_SHI_RO_256_PLUS), meanPoisson));
+                SmallMeanPoissonSampler.of(RandomSource.XO_SHI_RO_256_PLUS.create(), meanPoisson));
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                KempSmallMeanPoissonSampler.of(RandomSource.create(RandomSource.XO_SHI_RO_128_PLUS), meanPoisson));
+                KempSmallMeanPoissonSampler.of(RandomSource.XO_SHI_RO_128_PLUS.create(), meanPoisson));
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.create(RandomSource.XO_SHI_RO_128_PLUS), meanPoisson));
+                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.XO_SHI_RO_128_PLUS.create(), meanPoisson));
             // LargeMeanPoissonSampler should work at small mean.
             // Note: This hits a code path where the sample from the normal distribution is rejected.
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, meanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(10, 0, 1),
-                LargeMeanPoissonSampler.of(RandomSource.create(RandomSource.PCG_MCG_XSH_RR_32), meanPoisson));
+                LargeMeanPoissonSampler.of(RandomSource.PCG_MCG_XSH_RR_32.create(), meanPoisson));
             // Poisson (40 < mean < 80).
             final double largeMeanPoisson = 67.89;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, largeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(50, (int) (largeMeanPoisson - 25), 1),
-                PoissonSampler.of(RandomSource.create(RandomSource.SPLIT_MIX_64), largeMeanPoisson));
+                PoissonSampler.of(RandomSource.SPLIT_MIX_64.create(), largeMeanPoisson));
             // Dedicated large mean poisson sampler
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, largeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(50, (int) (largeMeanPoisson - 25), 1),
-                LargeMeanPoissonSampler.of(RandomSource.create(RandomSource.SPLIT_MIX_64), largeMeanPoisson));
+                LargeMeanPoissonSampler.of(RandomSource.SPLIT_MIX_64.create(), largeMeanPoisson));
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, largeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(50, (int) (largeMeanPoisson - 25), 1),
-                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PLUS), largeMeanPoisson));
+                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.XO_RO_SHI_RO_128_PLUS.create(), largeMeanPoisson));
             // Poisson (mean >> 40).
             final double veryLargeMeanPoisson = 543.21;
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, veryLargeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(100, (int) (veryLargeMeanPoisson - 50), 1),
-                PoissonSampler.of(RandomSource.create(RandomSource.SPLIT_MIX_64), veryLargeMeanPoisson));
+                PoissonSampler.of(RandomSource.SPLIT_MIX_64.create(), veryLargeMeanPoisson));
             // Dedicated large mean poisson sampler
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, veryLargeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(100, (int) (veryLargeMeanPoisson - 50), 1),
-                LargeMeanPoissonSampler.of(RandomSource.create(RandomSource.SPLIT_MIX_64), veryLargeMeanPoisson));
+                LargeMeanPoissonSampler.of(RandomSource.SPLIT_MIX_64.create(), veryLargeMeanPoisson));
             add(LIST, new org.apache.commons.math3.distribution.PoissonDistribution(unusedRng, veryLargeMeanPoisson, epsilonPoisson, maxIterationsPoisson),
                 MathArrays.sequence(100, (int) (veryLargeMeanPoisson - 50), 1),
-                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.create(RandomSource.XO_RO_SHI_RO_64_SS), veryLargeMeanPoisson));
+                MarsagliaTsangWangDiscreteSampler.Poisson.of(RandomSource.XO_RO_SHI_RO_64_SS.create(), veryLargeMeanPoisson));
 
             // Any discrete distribution
             final double[] discreteProbabilities = new double[] {0.1, 0.2, 0.3, 0.4, 0.5};
             add(LIST, discreteProbabilities,
-                MarsagliaTsangWangDiscreteSampler.Enumerated.of(RandomSource.create(RandomSource.XO_SHI_RO_512_PLUS), discreteProbabilities));
+                MarsagliaTsangWangDiscreteSampler.Enumerated.of(RandomSource.XO_SHI_RO_512_PLUS.create(), discreteProbabilities));
             add(LIST, discreteProbabilities,
-                GuideTableDiscreteSampler.of(RandomSource.create(RandomSource.XO_SHI_RO_512_SS), discreteProbabilities));
+                GuideTableDiscreteSampler.of(RandomSource.XO_SHI_RO_512_SS.create(), discreteProbabilities));
             add(LIST, discreteProbabilities,
-                AliasMethodDiscreteSampler.of(RandomSource.create(RandomSource.KISS), discreteProbabilities));
+                AliasMethodDiscreteSampler.of(RandomSource.KISS.create(), discreteProbabilities));
         } catch (Exception e) {
             // CHECKSTYLE: stop Regexp
             System.err.println("Unexpected exception while creating the list of samplers: " + e);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/DiscreteUniformSamplerTest.java
@@ -37,7 +37,7 @@ public class DiscreteUniformSamplerTest {
     public void testConstructorThrowsWithLowerAboveUpper() {
         final int upper = 55;
         final int lower = upper + 1;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         DiscreteUniformSampler.of(rng, lower, upper);
     }
 
@@ -45,7 +45,7 @@ public class DiscreteUniformSamplerTest {
     public void testSamplesWithRangeOf1() {
         final int upper = 99;
         final int lower = upper;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
         final SharedStateDiscreteSampler sampler = DiscreteUniformSampler.of(rng, lower, upper);
         for (int i = 0; i < 5; i++) {
             Assert.assertEquals(lower, sampler.sample());
@@ -60,8 +60,8 @@ public class DiscreteUniformSamplerTest {
     public void testSamplesWithFullRange() {
         final int upper = Integer.MAX_VALUE;
         final int lower = Integer.MIN_VALUE;
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler = DiscreteUniformSampler.of(rng2, lower, upper);
         for (int i = 0; i < 5; i++) {
             Assert.assertEquals(rng1.nextInt(), sampler.sample());
@@ -115,9 +115,9 @@ public class DiscreteUniformSamplerTest {
 
     private static void assertOffsetSamples(int range) {
         final Long seed = RandomSource.createLong();
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
-        final UniformRandomProvider rng3 = RandomSource.create(RandomSource.SPLIT_MIX_64, seed);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(seed);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(seed);
+        final UniformRandomProvider rng3 = RandomSource.SPLIT_MIX_64.create(seed);
 
         // Since the upper limit is inclusive
         range = range - 1;
@@ -299,8 +299,8 @@ public class DiscreteUniformSamplerTest {
      * @param upper Upper.
      */
     private static void testSharedStateSampler(int lower, int upper) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         // Use instance constructor not factory constructor to exercise 1.X public API
         final SharedStateDiscreteSampler sampler1 =
             new DiscreteUniformSampler(rng1, lower, upper);
@@ -337,7 +337,7 @@ public class DiscreteUniformSamplerTest {
      * @param upper Upper.
      */
     private static void assertToString(int lower, int upper) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final DiscreteUniformSampler sampler =
             new DiscreteUniformSampler(rng, lower, upper);
         Assert.assertTrue(sampler.toString().toLowerCase(Locale.US).contains("uniform"));

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GaussianSamplerTest.java
@@ -33,7 +33,7 @@ public class GaussianSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroStandardDeviation() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
         final double mean = 1;
         final double standardDeviation = 0;
@@ -45,8 +45,8 @@ public class GaussianSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng1);
         final double mean = 1.23;
         final double standardDeviation = 4.56;
@@ -62,7 +62,7 @@ public class GaussianSamplerTest {
      */
     @Test(expected = UnsupportedOperationException.class)
     public void testSharedStateSamplerThrowsIfUnderlyingSamplerDoesNotShareState() {
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new NormalizedGaussianSampler() {
             @Override
             public double sample() {
@@ -82,7 +82,7 @@ public class GaussianSamplerTest {
      */
     @Test(expected = UnsupportedOperationException.class)
     public void testSharedStateSamplerThrowsIfUnderlyingSamplerReturnsWrongSharedState() {
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new BadSharedStateNormalizedGaussianSampler();
         final double mean = 1.23;
         final double standardDeviation = 4.56;

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GeometricSamplerTest.java
@@ -32,7 +32,7 @@ public class GeometricSamplerTest {
      */
     @Test
     public void testProbabilityOfSuccessIsOneGeneratesZeroForSamples() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler = GeometricSampler.of(rng, 1);
         // All samples should be 0
         for (int i = 0; i < 10; i++) {
@@ -55,7 +55,7 @@ public class GeometricSamplerTest {
         Assert.assertTrue(exponentialMean > 0 && exponentialMean <= Double.MAX_VALUE);
         // The internal exponential sampler validates the mean so demonstrate creating a
         // geometric sampler does not throw.
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         GeometricSampler.of(rng, probabilityOfSuccess);
     }
 
@@ -65,7 +65,7 @@ public class GeometricSamplerTest {
      */
     @Test
     public void testProbabilityOfSuccessIsOneSamplerToString() {
-        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider unusedRng = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler = GeometricSampler.of(unusedRng, 1);
         Assert.assertTrue("Missing 'Geometric' from toString",
             sampler.toString().contains("Geometric"));
@@ -82,7 +82,7 @@ public class GeometricSamplerTest {
      */
     @Test
     public void testProbabilityOfSuccessIsAlmostZeroGeneratesMaxValueForSamples() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler = GeometricSampler.of(rng, Double.MIN_VALUE);
         // All samples should be max value
         for (int i = 0; i < 10; i++) {
@@ -96,7 +96,7 @@ public class GeometricSamplerTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testProbabilityOfSuccessAboveOneThrows() {
-        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider unusedRng = RandomSource.SPLIT_MIX_64.create(0L);
         final double probabilityOfSuccess = Math.nextUp(1.0);
         GeometricSampler.of(unusedRng, probabilityOfSuccess);
     }
@@ -106,7 +106,7 @@ public class GeometricSamplerTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testProbabilityOfSuccessIsZeroThrows() {
-        final UniformRandomProvider unusedRng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider unusedRng = RandomSource.SPLIT_MIX_64.create(0L);
         final double probabilityOfSuccess = 0;
         GeometricSampler.of(unusedRng, probabilityOfSuccess);
     }
@@ -134,8 +134,8 @@ public class GeometricSamplerTest {
      * @param probabilityOfSuccess Probability of success.
      */
     private static void testSharedStateSampler(double probabilityOfSuccess) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler1 =
             GeometricSampler.of(rng1, probabilityOfSuccess);
         final SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/GuideTableDiscreteSamplerTest.java
@@ -87,7 +87,7 @@ public class GuideTableDiscreteSamplerTest {
      * @return the alias method discrete sampler
      */
     private static SharedStateDiscreteSampler createSampler(double[] probabilities, double alpha) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
         return GuideTableDiscreteSampler.of(rng, probabilities, alpha);
     }
 
@@ -241,8 +241,8 @@ public class GuideTableDiscreteSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] probabilities = {0.1, 0, 0.2, 0.3, 0.1, 0.3, 0};
         final SharedStateDiscreteSampler sampler1 =
             GuideTableDiscreteSampler.of(rng1, probabilities);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformContinuousSamplerTest.java
@@ -37,8 +37,8 @@ public class InverseTransformContinuousSamplerTest {
                     return 456.99 * p;
                 }
         };
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateContinuousSampler sampler1 =
             InverseTransformContinuousSampler.of(rng1, function);
         final SharedStateContinuousSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformDiscreteSamplerTest.java
@@ -37,8 +37,8 @@ public class InverseTransformDiscreteSamplerTest {
                     return (int) Math.round(789 * p);
                 }
         };
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler1 =
             InverseTransformDiscreteSampler.of(rng1, function);
         final SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/InverseTransformParetoSamplerTest.java
@@ -32,7 +32,7 @@ public class InverseTransformParetoSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroScale() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double scale = 0;
         final double shape = 1;
         InverseTransformParetoSampler.of(rng, scale, shape);
@@ -44,7 +44,7 @@ public class InverseTransformParetoSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double scale = 1;
         final double shape = 0;
         InverseTransformParetoSampler.of(rng, scale, shape);
@@ -55,8 +55,8 @@ public class InverseTransformParetoSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double scale = 1.23;
         final double shape = 4.56;
         final SharedStateContinuousSampler sampler1 =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/KempSmallMeanPoissonSamplerTest.java
@@ -151,8 +151,8 @@ public class KempSmallMeanPoissonSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 1.23;
         final SharedStateDiscreteSampler sampler1 =
             KempSmallMeanPoissonSampler.of(rng1, mean);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LargeMeanPoissonSamplerTest.java
@@ -39,7 +39,7 @@ public class LargeMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithMeanLargerThanUpperBound() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = Integer.MAX_VALUE / 2 + 1;
         LargeMeanPoissonSampler.of(rng, mean);
     }
@@ -50,7 +50,7 @@ public class LargeMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithMeanBelow1() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = Math.nextAfter(1, -1);
         LargeMeanPoissonSampler.of(rng, mean);
     }
@@ -61,7 +61,7 @@ public class LargeMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithStateAndNegativeFractionalMean() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final LargeMeanPoissonSamplerState state = new LargeMeanPoissonSampler(rng, 1).getState();
         @SuppressWarnings("unused")
         LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, -0.1);
@@ -73,7 +73,7 @@ public class LargeMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithStateAndNonFractionalMean() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final LargeMeanPoissonSamplerState state = new LargeMeanPoissonSampler(rng, 1).getState();
         @SuppressWarnings("unused")
         LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, 1.1);
@@ -85,7 +85,7 @@ public class LargeMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithStateAndFractionalMeanOne() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final LargeMeanPoissonSamplerState state = new LargeMeanPoissonSampler(rng, 1).getState();
         @SuppressWarnings("unused")
         LargeMeanPoissonSampler sampler = new LargeMeanPoissonSampler(rng, state, 1);
@@ -101,10 +101,10 @@ public class LargeMeanPoissonSamplerTest {
     public void testCanComputeSameSamplesWhenConstructedWithState() {
         // Two identical RNGs
         final RestorableUniformRandomProvider rng1 =
-                RandomSource.create(RandomSource.MWC_256);
+                RandomSource.MWC_256.create();
         final RandomProviderState state = rng1.saveState();
         final RestorableUniformRandomProvider rng2 =
-                RandomSource.create(RandomSource.MWC_256);
+                RandomSource.MWC_256.create();
         rng2.restoreState(state);
 
         // The sampler is suitable for mean > 40
@@ -163,8 +163,8 @@ public class LargeMeanPoissonSamplerTest {
      * @param mean Mean.
      */
     private static void testSharedStateSampler(double mean) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler1 =
             LargeMeanPoissonSampler.of(rng1, mean);
         final SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LogNormalSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/LogNormalSamplerTest.java
@@ -33,7 +33,7 @@ public class LogNormalSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithNegativeScale() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
         final double scale = -1e-6;
         final double shape = 1;
@@ -46,7 +46,7 @@ public class LogNormalSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroShape() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng);
         final double scale = 1;
         final double shape = 0;
@@ -58,8 +58,8 @@ public class LogNormalSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new ZigguratNormalizedGaussianSampler(rng1);
         final double scale = 1.23;
         final double shape = 4.56;
@@ -75,7 +75,7 @@ public class LogNormalSamplerTest {
      */
     @Test(expected = UnsupportedOperationException.class)
     public void testSharedStateSamplerThrowsIfUnderlyingSamplerDoesNotShareState() {
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new NormalizedGaussianSampler() {
             @Override
             public double sample() {
@@ -95,7 +95,7 @@ public class LogNormalSamplerTest {
      */
     @Test(expected = UnsupportedOperationException.class)
     public void testSharedStateSamplerThrowsIfUnderlyingSamplerReturnsWrongSharedState() {
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final NormalizedGaussianSampler gauss = new BadSharedStateNormalizedGaussianSampler();
         final double scale = 1.23;
         final double shape = 4.56;

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalisedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaNormalisedGaussianSamplerTest.java
@@ -32,8 +32,8 @@ public class MarsagliaNormalisedGaussianSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateContinuousSampler sampler1 =
             MarsagliaNormalizedGaussianSampler.<MarsagliaNormalizedGaussianSampler>of(rng1);
         final SharedStateContinuousSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaTsangWangDiscreteSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/MarsagliaTsangWangDiscreteSamplerTest.java
@@ -182,7 +182,7 @@ public class MarsagliaTsangWangDiscreteSamplerTest {
     public void testRealProbabilityDistributionSamples() {
         // These do not have to sum to 1
         final double[] probabilities = new double[11];
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create();
         for (int i = 0; i < probabilities.length; i++) {
             probabilities[i] = rng.nextDouble();
         }
@@ -613,8 +613,8 @@ public class MarsagliaTsangWangDiscreteSamplerTest {
      * @param prob Probability values.
      */
     private static void testSharedStateSampler(int offset, int[] prob) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         double[] probabilities = createProbabilities(offset, prob);
         final SharedStateDiscreteSampler sampler1 =
                 MarsagliaTsangWangDiscreteSampler.Enumerated.of(rng1, probabilities);
@@ -647,8 +647,8 @@ public class MarsagliaTsangWangDiscreteSamplerTest {
      * @param probabilityOfSuccess Probability of success.
      */
     private static void testSharedStateSampler(int trials, double probabilityOfSuccess) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateDiscreteSampler sampler1 =
                 MarsagliaTsangWangDiscreteSampler.Binomial.of(rng1, trials, probabilityOfSuccess);
         final SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerCacheTest.java
@@ -247,7 +247,7 @@ public class PoissonSamplerCacheTest {
     @Test(expected = IllegalArgumentException.class)
     public void testCreateSharedStateSamplerThrowsWithZeroMean() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final PoissonSamplerCache cache = createPoissonSamplerCache();
         cache.createSharedStateSampler(rng, 0);
     }
@@ -258,7 +258,7 @@ public class PoissonSamplerCacheTest {
     @Test(expected = IllegalArgumentException.class)
     public void testCreateSharedStateSamplerThrowsWithNonIntegerMean() {
         final RestorableUniformRandomProvider rng =
-                RandomSource.create(RandomSource.SPLIT_MIX_64);
+                RandomSource.SPLIT_MIX_64.create(0L);
         final PoissonSamplerCache cache = createPoissonSamplerCache();
         final double mean = Integer.MAX_VALUE + 1.0;
         cache.createSharedStateSampler(rng, mean);
@@ -328,10 +328,8 @@ public class PoissonSamplerCacheTest {
         // Two identical RNGs
         final RandomSource source = RandomSource.SPLIT_MIX_64;
         final long seed = RandomSource.createLong();
-        final RestorableUniformRandomProvider rng1 =
-                RandomSource.create(source, seed);
-        final RestorableUniformRandomProvider rng2 =
-                RandomSource.create(source, seed);
+        final RestorableUniformRandomProvider rng1 = source.create(seed);
+        final RestorableUniformRandomProvider rng2 = source.create(seed);
 
         // Create the cache with the given range
         final PoissonSamplerCache cache =
@@ -457,10 +455,8 @@ public class PoissonSamplerCacheTest {
         // Two identical RNGs
         final RandomSource source = RandomSource.SPLIT_MIX_64;
         final long seed = RandomSource.createLong();
-        final RestorableUniformRandomProvider rng1 =
-                RandomSource.create(source, seed);
-        final RestorableUniformRandomProvider rng2 =
-                RandomSource.create(source, seed);
+        final RestorableUniformRandomProvider rng1 = source.create(seed);
+        final RestorableUniformRandomProvider rng2 = source.create(seed);
 
         // Create the cache with the given range and fill it
         final PoissonSamplerCache cache =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/PoissonSamplerTest.java
@@ -50,8 +50,8 @@ public class PoissonSamplerTest {
      * @param mean Mean.
      */
     private static void testSharedStateSampler(double mean) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         // Use instance constructor not factory constructor to exercise 1.X public API
         final SharedStateDiscreteSampler sampler1 =
             new PoissonSampler(rng1, mean);
@@ -65,7 +65,7 @@ public class PoissonSamplerTest {
      */
     @Test
     public void testToString() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         Assert.assertTrue(new PoissonSampler(rng, 1.23).toString().toLowerCase().contains("poisson"));
     }
 }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSamplerTest.java
@@ -32,7 +32,7 @@ public class RejectionInversionZipfSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroNumberOfElements() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final int numberOfElements = 0;
         final double exponent = 1;
         RejectionInversionZipfSampler.of(rng, numberOfElements, exponent);
@@ -44,7 +44,7 @@ public class RejectionInversionZipfSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroExponent() {
         final RestorableUniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final int numberOfElements = 1;
         final double exponent = 0;
         RejectionInversionZipfSampler.of(rng, numberOfElements, exponent);
@@ -55,8 +55,8 @@ public class RejectionInversionZipfSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final int numberOfElements = 7;
         final double exponent = 1.23;
         final SharedStateDiscreteSampler sampler1 =

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SamplerBaseTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SamplerBaseTest.java
@@ -58,8 +58,8 @@ public class SamplerBaseTest {
 
     @Test
     public void testNextMethods() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SimpleSampler sampler = new SimpleSampler(rng2);
         final int n = 256;
         for (int i = 0; i < 3; i++) {
@@ -72,7 +72,7 @@ public class SamplerBaseTest {
 
     @Test
     public void testToString() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final SimpleSampler sampler = new SimpleSampler(rng);
         Assert.assertTrue(sampler.toString().contains("rng"));
     }

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SmallMeanPoissonSamplerTest.java
@@ -32,7 +32,7 @@ public class SmallMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithMeanThatSetsProbabilityP0ToZero() {
         final UniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double p0 = Double.MIN_VALUE;
         // Note: p0 = Math.exp(-mean) => mean = -Math.log(p0).
         // Add to the limit on the mean to cause p0 to be zero.
@@ -46,7 +46,7 @@ public class SmallMeanPoissonSamplerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorThrowsWithZeroMean() {
         final UniformRandomProvider rng =
-            RandomSource.create(RandomSource.SPLIT_MIX_64);
+            RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 0;
         SmallMeanPoissonSampler.of(rng, mean);
     }
@@ -82,8 +82,8 @@ public class SmallMeanPoissonSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double mean = 1.23;
         final SharedStateDiscreteSampler sampler1 =
             SmallMeanPoissonSampler.of(rng1, mean);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/ZigguratNormalizedGaussianSamplerTest.java
@@ -53,8 +53,8 @@ public class ZigguratNormalizedGaussianSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final SharedStateContinuousSampler sampler1 =
             ZigguratNormalizedGaussianSampler.<ZigguratNormalizedGaussianSampler>of(rng1);
         final SharedStateContinuousSampler sampler2 = sampler1.withUniformRandomProvider(rng2);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/BoxSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/BoxSamplerTest.java
@@ -37,7 +37,7 @@ public class BoxSamplerTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidDimensionThrows() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         BoxSampler.of(new double[1], new double[1], rng);
     }
 
@@ -46,7 +46,7 @@ public class BoxSamplerTest {
      */
     @Test
     public void testDimensionMismatchThrows() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c2 = new double[2];
         final double[] c3 = new double[3];
         for (double[][] c : new double[][][] {
@@ -68,7 +68,7 @@ public class BoxSamplerTest {
      */
     @Test
     public void testNonFiniteVertexCoordinates() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         // A valid box
         final double[][] c = new double[][] {
             {0, 1, 2}, {-1, 2, 3}
@@ -146,9 +146,9 @@ public class BoxSamplerTest {
             Double.POSITIVE_INFINITY, c2[1][0] - c2[0][0], 0.0);
 
         final BoxSampler sampler1 = BoxSampler.of(c1[0], c1[1],
-            RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+            RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
         final BoxSampler sampler2 = BoxSampler.of(c2[0], c2[1],
-            RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+            RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
 
         for (int n = 0; n < 10; n++) {
             final double[] a = sampler1.sample();
@@ -191,7 +191,7 @@ public class BoxSamplerTest {
      * @param dimension the dimension
      */
     private static void testDistributionND(int dimension) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.JSF_64, 0xdabfab);
+        final UniformRandomProvider rng = RandomSource.JSF_64.create(0xdabfab);
 
         final UnitSphereSampler sphere = UnitSphereSampler.of(dimension, rng);
         final double[] a = sphere.sample();
@@ -273,8 +273,8 @@ public class BoxSamplerTest {
      * Test the SharedStateSampler implementation for the given dimension.
      */
     private static void testSharedStateSampler(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final BoxSampler sampler1 = BoxSampler.of(c1, c2, rng1);
@@ -325,8 +325,8 @@ public class BoxSamplerTest {
      * @param dimension the dimension
      */
     private static void testChangedInputCoordinates(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final BoxSampler sampler1 = BoxSampler.of(c1, c2, rng1);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/LineSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/LineSamplerTest.java
@@ -37,7 +37,7 @@ public class LineSamplerTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidDimensionThrows() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         LineSampler.of(new double[0], new double[0], rng);
     }
 
@@ -46,7 +46,7 @@ public class LineSamplerTest {
      */
     @Test
     public void testDimensionMismatchThrows() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c2 = new double[2];
         final double[] c3 = new double[3];
         for (double[][] c : new double[][][] {
@@ -68,7 +68,7 @@ public class LineSamplerTest {
      */
     @Test
     public void testNonFiniteVertexCoordinates() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         // A valid line
         final double[][] c = new double[][] {
             {0, 1, 2}, {-1, 2, 3}
@@ -156,9 +156,9 @@ public class LineSamplerTest {
             Double.POSITIVE_INFINITY, c2[1][0] - c2[0][0], 0.0);
 
         final LineSampler sampler1 = LineSampler.of(c1[0], c1[1],
-            RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+            RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
         final LineSampler sampler2 = LineSampler.of(c2[0], c2[1],
-            RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+            RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
 
         for (int n = 0; n < 10; n++) {
             final double[] a = sampler1.sample();
@@ -209,7 +209,7 @@ public class LineSamplerTest {
      * @param dimension the dimension
      */
     private static void testDistributionND(int dimension) {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SFC_64, 0xfabcab);
+        final UniformRandomProvider rng = RandomSource.SFC_64.create(0xfabcab);
 
         double[] a;
         double[] b;
@@ -300,8 +300,8 @@ public class LineSamplerTest {
      * Test the SharedStateSampler implementation for the given dimension.
      */
     private static void testSharedStateSampler(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final LineSampler sampler1 = LineSampler.of(c1, c2, rng1);
@@ -360,8 +360,8 @@ public class LineSamplerTest {
      * @param dimension the dimension
      */
     private static void testChangedInputCoordinates(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final LineSampler sampler1 = LineSampler.of(c1, c2, rng1);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/TetrahedronSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/TetrahedronSamplerTest.java
@@ -36,7 +36,7 @@ public class TetrahedronSamplerTest {
      */
     @Test
     public void testInvalidDimensionThrows() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] ok = new double[3];
         final double[] bad = new double[2];
         final double[][] c = {ok, ok, ok, ok};
@@ -57,7 +57,7 @@ public class TetrahedronSamplerTest {
      */
     @Test
     public void testNonFiniteVertexCoordinates() {
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
         // A valid tetrahedron
         final double[][] c = new double[][] {
             {1, 1, 1}, {1, -1, 1}, {-1, 1, 1}, {1, 1, -1}
@@ -111,9 +111,9 @@ public class TetrahedronSamplerTest {
                 Double.POSITIVE_INFINITY, c2[2][2] - c2[1][2], 0.0);
 
         final TetrahedronSampler sampler1 = TetrahedronSampler.of(c1[0], c1[1], c1[2], c1[3],
-                RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+                RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
         final TetrahedronSampler sampler2 = TetrahedronSampler.of(c2[0], c2[1], c2[2], c2[3],
-                RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+                RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
 
         for (int n = 0; n < 10; n++) {
             final double[] a = sampler1.sample();
@@ -167,7 +167,7 @@ public class TetrahedronSamplerTest {
         Arrays.fill(expected, 1);
 
         // Increase the loops and use a null seed (i.e. randomly generated) to verify robustness
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_512_PP, 0xaabbccddeeffL);
+        final UniformRandomProvider rng = RandomSource.XO_SHI_RO_512_PP.create(0xaabbccddeeffL);
 
         // Cut the box into 6 equal volume tetrahedra by cutting the box in half three times,
         // cutting diagonally through each of the three pairs of opposing faces. In this way,
@@ -251,8 +251,8 @@ public class TetrahedronSamplerTest {
      */
     @Test
     public void testSharedStateSampler() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(-1);
         final double[] c2 = createCoordinate(2);
         final double[] c3 = createCoordinate(-3);
@@ -279,8 +279,8 @@ public class TetrahedronSamplerTest {
      */
     @Test
     public void testChangedInputCoordinates() {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1);
         final double[] c2 = createCoordinate(2);
         final double[] c3 = createCoordinate(-3);

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/TriangleSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/TriangleSamplerTest.java
@@ -82,7 +82,7 @@ public class TriangleSamplerTest {
         // Test that a(1 - s - t) + sb + tc does not overflow is s+t = 1
         final double max = Double.MAX_VALUE;
         s -= delta;
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+        final UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
         for (int n = 0; n < 100; n++) {
             Assert.assertNotEquals(Double.POSITIVE_INFINITY, (1 - s - t) * max + s * max + t * max, 0.0);
             s = rng.nextDouble();
@@ -215,9 +215,9 @@ public class TriangleSamplerTest {
                 Double.NEGATIVE_INFINITY, c2[2][1] - c2[1][1], 0.0);
 
         final TriangleSampler sampler1 = TriangleSampler.of(c1[0],  c1[1],  c1[2],
-                RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+                RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
         final TriangleSampler sampler2 = TriangleSampler.of(c2[0],  c2[1],  c2[2],
-                RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP, seed));
+                RandomSource.XO_RO_SHI_RO_128_PP.create(seed));
 
         for (int n = 0; n < 10; n++) {
             final double[] a = sampler1.sample();
@@ -312,7 +312,7 @@ public class TriangleSamplerTest {
         }
 
         // Increase the loops and use a null seed (i.e. randomly generated) to verify robustness
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_512_PP, 0xfabcab);
+        final UniformRandomProvider rng = RandomSource.XO_SHI_RO_512_PP.create(0xfabcab);
         final TriangleSampler sampler1 = TriangleSampler.of(forward.apply(a), forward.apply(d), forward.apply(b), rng);
         final TriangleSampler sampler2 = TriangleSampler.of(forward.apply(b), forward.apply(c), forward.apply(e), rng);
         final TriangleSampler sampler3 = TriangleSampler.of(forward.apply(c), forward.apply(d), forward.apply(e), rng);
@@ -390,8 +390,8 @@ public class TriangleSamplerTest {
      * Test the SharedStateSampler implementation for the given dimension.
      */
     private static void testSharedStateSampler(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final double[] c3 = createCoordinate(-3, dimension);
@@ -443,8 +443,8 @@ public class TriangleSamplerTest {
      * @param dimension the dimension
      */
     private static void testChangedInputCoordinates(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final double[] c1 = createCoordinate(1, dimension);
         final double[] c2 = createCoordinate(2, dimension);
         final double[] c3 = createCoordinate(-3, dimension);
@@ -523,7 +523,7 @@ public class TriangleSamplerTest {
             throw new AssertionError("Unsupported dimension: " + dimension);
         }
 
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 789L);
+        final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(789L);
         double sum = 0;
         for (int n = 0; n < 10; n++) {
             final double[] a = new double[] {rng.nextDouble(), rng.nextDouble()};

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/UnitBallSamplerTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/shape/UnitBallSamplerTest.java
@@ -125,7 +125,7 @@ public class UnitBallSamplerTest {
         Arrays.fill(expected, (double) samples / layers);
 
         // Increase the loops and use a null seed (i.e. randomly generated) to verify robustness
-        final UniformRandomProvider rng = RandomSource.create(RandomSource.XO_SHI_RO_512_PP, 0xa1b2c3d4L);
+        final UniformRandomProvider rng = RandomSource.XO_SHI_RO_512_PP.create(0xa1b2c3d4L);
         final UnitBallSampler sampler = UnitBallSampler.of(dimension, rng);
         for (int loop = 0; loop < 1; loop++) {
             // Assign each coordinate to a layer inside the ball and an orthant using the sign
@@ -224,8 +224,8 @@ public class UnitBallSamplerTest {
      * Test the SharedStateSampler implementation for the given dimension.
      */
     private static void testSharedStateSampler(int dimension) {
-        final UniformRandomProvider rng1 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
-        final UniformRandomProvider rng2 = RandomSource.create(RandomSource.SPLIT_MIX_64, 0L);
+        final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
+        final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
         final UnitBallSampler sampler1 = UnitBallSampler.of(dimension, rng1);
         final UnitBallSampler sampler2 = sampler1.withUniformRandomProvider(rng2);
         RandomAssert.assertProduceSameSequence(

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/JDKRandomBridge.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/JDKRandomBridge.java
@@ -59,7 +59,7 @@ public final class JDKRandomBridge extends Random {
     public JDKRandomBridge(RandomSource source,
                            Object seed) {
         this.source = source;
-        delegate = RandomSource.create(source, seed);
+        delegate = source.create(seed);
         isInitialized = true;
     }
 
@@ -67,7 +67,7 @@ public final class JDKRandomBridge extends Random {
     @Override
     public synchronized void setSeed(long seed) {
         if (isInitialized) {
-            delegate = RandomSource.create(source, seed);
+            delegate = source.create(seed);
 
             // Force the clearing of the "haveNextNextGaussian" flag
             // (cf. Javadoc of the base class); the value passed here
@@ -128,7 +128,7 @@ public final class JDKRandomBridge extends Random {
         input.defaultReadObject();
 
         // Recreate the "delegate" from serialized info.
-        delegate = RandomSource.create(source);
+        delegate = source.create();
         // And restore its state.
         // Avoid the use of input.readObject() to deserialize by manually reading the byte[].
         // Note: ObjectInputStream.readObject() will execute the readObject() method of the named

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/ThreadLocalRandomSource.java
@@ -24,7 +24,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  * This class provides a thread-local {@link UniformRandomProvider}.
  *
  * <p>The {@link UniformRandomProvider} is created once-per-thread using the default
- * construction method {@link RandomSource#create(RandomSource)}.
+ * construction method {@link RandomSource#create()}.
  *
  * <p>Example:</p>
  * <pre><code>
@@ -52,7 +52,7 @@ import org.apache.commons.rng.UniformRandomProvider;
  *     new ThreadLocal&lt;UniformRandomProvider&gt;() {
  *         &#64;Override
  *         protected UniformRandomProvider initialValue() {
- *             return RandomSource.create(RandomSource.TWO_CMRES_SELECT, null, 3, 4);
+ *             return RandomSource.TWO_CMRES_SELECT.create(null, 3, 4);
  *         }
  *     };
  *
@@ -95,14 +95,14 @@ public final class ThreadLocalRandomSource {
         @Override
         protected UniformRandomProvider initialValue() {
             // Create with the default seed generation method
-            return RandomSource.create(source);
+            return source.create();
         }
     }
 
     /**
      * Returns the current thread's copy of the given {@code source}. If there is no
      * value for the current thread, it is first initialized to the value returned
-     * by {@link RandomSource#create(RandomSource)}.
+     * by {@link RandomSource#create()}.
      *
      * <p>Note if the {@code source} requires additional arguments then it is not
      * supported.

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
@@ -87,8 +87,8 @@ public final class ProviderBuilder {
      *
      * @param source RNG specification.
      * @return a new RNG instance.
-     * @throws IllegalStateException if data is missing to initialize the
-     * generator implemented by the given {@code source}.
+     * @throws IllegalArgumentException if argument data to initialize the
+     * generator implemented by the given {@code source} is missing.
      * @since 1.3
      */
     public static RestorableUniformRandomProvider create(RandomSourceInternal source) {
@@ -105,8 +105,8 @@ public final class ProviderBuilder {
      * @param args Additional arguments to the implementation's constructor.
      * @return a new RNG instance.
      * @throws UnsupportedOperationException if the seed type is invalid.
-     * @throws IllegalStateException if data is missing to initialize the
-     * generator implemented by the given {@code source}.
+     * @throws IllegalArgumentException if argument data to initialize the
+     * generator implemented by the given {@code source} is invalid.
      */
     public static RestorableUniformRandomProvider create(RandomSourceInternal source,
                                                          Object seed,

--- a/commons-rng-simple/src/site/xdoc/index.xml
+++ b/commons-rng-simple/src/site/xdoc/index.xml
@@ -44,7 +44,7 @@
 import org.apache.commons.rng.simple.RandomSource;
 
 public class Dice {
-    private final UniformRandomProvider rng = RandomSource.create(RandomSource.MT);
+    private final UniformRandomProvider rng = RandomSource.MT_64.create();
 
     public int roll() {
         return 1 + rng.nextInt(6);

--- a/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ThreadLocalRandomSourceTest.java
+++ b/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ThreadLocalRandomSourceTest.java
@@ -49,7 +49,7 @@ public class ThreadLocalRandomSourceTest {
         ThreadLocalRandomSource.current(null);
     }
 
-    //@Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testCurrentThrowsForRandomSourceWithDataArguments() {
         ThreadLocalRandomSource.current(RandomSource.TWO_CMRES_SELECT);
     }

--- a/src/site/apt/userguide/rng.apt
+++ b/src/site/apt/userguide/rng.apt
@@ -118,7 +118,7 @@
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.simple.RandomSource;
 
-UniformRandomProvider rng = RandomSource.create(RandomSource.MT);
+UniformRandomProvider rng = RandomSource.MT.create();
 +--------------------------+
 
 
@@ -161,7 +161,7 @@ rng.nextBytes(a, 15, 3);
   * In order to generate reproducible sequences, generators must be instantiated with a user-defined seed.
 
 +--------------------------+
-UniformRandomProvider rng = RandomSource.create(RandomSource.SPLIT_MIX_64, 5776);
+UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(5776);
 +--------------------------+
 
     If no seed is passed, a random seed is generated implicitly.
@@ -197,13 +197,13 @@ long[] seed = RandomSource.createLongArray(128); // Length of returned array is 
     []
 
 +--------------------------+
-UniformRandomProvider rng = RandomSource.create(RandomSource.ISAAC, 5776);
+UniformRandomProvider rng = RandomSource.ISAAC.create(5776);
 +--------------------------+
 +--------------------------+
-UniformRandomProvider rng = RandomSource.create(RandomSource.ISAAC, new int[] { 6, 7, 7, 5, 6, 1, 0, 2 });
+UniformRandomProvider rng = RandomSource.ISAAC.create(new int[] { 6, 7, 7, 5, 6, 1, 0, 2 });
 +--------------------------+
 +--------------------------+
-UniformRandomProvider rng = RandomSource.create(RandomSource.ISAAC, new long[] { 0x638a3fd83bc0e851L, 0x9730fd12c75ae247L });
+UniformRandomProvider rng = RandomSource.ISAAC.create(new long[] { 0x638a3fd83bc0e851L, 0x9730fd12c75ae247L });
 +--------------------------+
 
     Note however that, upon initialization, the underlying generation algorithm
@@ -244,7 +244,7 @@ if (!RandomSource.TWO_CMRES.isNativeSeed(seed)) {
 int seed = 96912062;
 int first = 7; // Subcycle identifier.
 int second = 4; // Subcycle identifier.
-UniformRandomProvider rng = RandomSource.create(RandomSource.TWO_CMRES_SELECT, seed, first, second);
+UniformRandomProvider rng = RandomSource.TWO_CMRES_SELECT.create(seed, first, second);
 +--------------------------+
 
     In the above example, valid "subcycle identifiers" are in the interval [0, 13].
@@ -260,7 +260,7 @@ UniformRandomProvider rng = RandomSource.create(RandomSource.TWO_CMRES_SELECT, s
 import org.apache.commons.rng.RestorableUniformRandomProvider;
 import org.apache.commons.rng.RandomProviderState;
 
-RestorableUniformRandomProvider rng = RandomSource.create(RandomSource.WELL_512_A);
+RestorableUniformRandomProvider rng = RandomSource.WELL_512_A.create();
 RandomProviderState state = rng.saveState();
 double x = rng.nextDouble();
 rng.restoreState(state);
@@ -283,7 +283,7 @@ import org.apache.commons.rng.core.RandomProviderDefaultState;
 
 RandomSource source = RandomSource.MT_64; // Known source identifier.
 
-RestorableUniformRandomProvider rngOrig = RandomSource.create(source); // Original RNG instance.
+RestorableUniformRandomProvider rngOrig = source.create(); // Original RNG instance.
 
 // Save and serialize state.
 RandomProviderState stateOrig = rngOrig.saveState(rngOrig);
@@ -296,7 +296,7 @@ ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
 ObjectInputStream ois = new ObjectInputStream(bis);
 RandomProviderState stateNew = new RandomProviderDefaultState((byte[]) ois.readObject());
 
-RestorableUniformRandomProvider rngNew = RandomSource.create(source); // New RNG instance from the same "source".
+RestorableUniformRandomProvider rngNew = source.create(); // New RNG instance from the same "source".
 
 // Restore original state on the new instance.
 rngNew.restoreState(stateNew);
@@ -314,7 +314,7 @@ import org.apache.commons.rng.simple.RandomSource;
 
 RandomSource source = RandomSource.XO_RO_SHI_RO_128_SS; // Known to be jumpable.
 
-JumpableUniformRandomProvider master = (JumpableUniformRandomProvider) RandomSource.create(source);
+JumpableUniformRandomProvider master = (JumpableUniformRandomProvider) source.create();
 
 // For use in parallel
 UniformRandomProvider[] rngs = new UniformRandomProvider[10];
@@ -346,7 +346,7 @@ import org.apache.commons.rng.sampling.distribution.ContinuousSampler;
 import org.apache.commons.rng.sampling.distribution.GaussianSampler;
 import org.apache.commons.rng.sampling.distribution.MarsagliaNormalizedGaussianSampler;
 
-ContinuousSampler sampler = GaussianSampler.of(MarsagliaNormalizedGaussianSampler.of(RandomSource.create(RandomSource.MT_64)),
+ContinuousSampler sampler = GaussianSampler.of(MarsagliaNormalizedGaussianSampler.of(RandomSource.MT_64.create()),
                                                45.6, 2.3);
 double random = sampler.sample();
 +--------------------------+
@@ -355,7 +355,7 @@ double random = sampler.sample();
 import org.apache.commons.rng.sampling.distribution.DiscreteSampler;
 import org.apache.commons.rng.sampling.distribution.RejectionInversionZipfSampler;
 
-DiscreteSampler sampler = RejectionInversionZipfSampler.of(RandomSource.create(RandomSource.ISAAC),
+DiscreteSampler sampler = RejectionInversionZipfSampler.of(RandomSource.ISAAC.create(),
                                                            5, 1.2);
 int random = sampler.sample();
 +--------------------------+
@@ -369,14 +369,14 @@ import org.apache.commons.rng.sampling.distribution.MarsagliaTsangWangDiscreteSa
 import org.apache.commons.rng.sampling.distribution.SharedStateDiscreteSampler;
 import org.apache.commons.rng.simple.RandomSource;
 
-RandomSource source = RandomSource.PCG_XSH_RR_32;
+RandomSource source = RandomSource.XO_RO_SHI_RO_128_PP;
 
 double[] probabilities = {0.1, 0.2, 0.3, 0.4};
-SharedStateDiscreteSampler sampler1 = MarsagliaTsangWangDiscreteSampler.Enumerated.of(RandomSource.create(source),
+SharedStateDiscreteSampler sampler1 = MarsagliaTsangWangDiscreteSampler.Enumerated.of(source.create(),
                                                                                       probabilities);
 
 // For use in parallel
-SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(RandomSource.create(source));
+SharedStateDiscreteSampler sampler2 = sampler1.withUniformRandomProvider(source.create());
 +--------------------------+
 
     All samplers support the <<<SharedStateSampler>>> interface.
@@ -395,13 +395,13 @@ int n = 6;
 int k = 3;
 
 // If the order of the elements matters.
-PermutationSampler permutationSampler = new PermutationSampler(RandomSource.create(RandomSource.KISS),
+PermutationSampler permutationSampler = new PermutationSampler(RandomSource.KISS.create(),
                                                                n, k);
 // n! / (n - k)! = 120 permutations.
 int[] permutation = permutationSampler.sample();
 
 // If the order of the elements does not matter.
-CombinationSampler combinationSampler = new CombinationSampler(RandomSource.create(RandomSource.KISS),
+CombinationSampler combinationSampler = new CombinationSampler(RandomSource.KISS.create(),
                                                                n, k);
 // n! / (k! (n - k)!) = 20 combinations.
 int[] combination = combinationSampler.sample();
@@ -416,7 +416,7 @@ list.add("Apache");
 list.add("Commons");
 list.add("RNG");
 
-CollectionSampler<String> sampler = new CollectionSampler<String>(RandomSource.create(RandomSource.MWC_256),
+CollectionSampler<String> sampler = new CollectionSampler<String>(RandomSource.MWC_256.create(),
                                                                   list, 1);
 String word = sampler.sample();
 +--------------------------+
@@ -429,7 +429,7 @@ import org.apache.commons.rng.sampling.ListSampler;
 
 List<String> list = Arrays.asList("Apache", "Commons", "RNG");
 
-UniformRandomProvider rng = RandomSource.create(RandomSource.PCG_XSH_RS_32);
+UniformRandomProvider rng = RandomSource.XO_RO_SHI_RO_128_PP.create();
 
 // Get 2 random items
 int k = 2;

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -39,7 +39,7 @@
 import org.apache.commons.rng.simple.RandomSource;
 
 // Instantiate a "Mersenne-Twister" generator with a factory method.
-UniformRandomProvider rng = RandomSource.create(RandomSource.MT);
+UniformRandomProvider rng = RandomSource.MT.create();
 
 // Use it to produce a floating-point value between 0 and 1.
 double random = rng.nextDouble();


### PR DESCRIPTION
Deprecate the RandomSource factory create method.

Update the unit tests and examples to use the instance create methods.