### PR TITLE
replace test child class with mocking object

### DIFF
--- a/commons-rng-sampling/pom.xml
+++ b/commons-rng-sampling/pom.xml
@@ -62,6 +62,13 @@
       <version>3.6.1</version>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.9.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SamplerBaseTest.java
+++ b/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SamplerBaseTest.java
@@ -20,47 +20,20 @@ import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.simple.RandomSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.spy;
 
 /**
  * Test for the {@link SamplerBase}. The class is deprecated but is public. The methods
  * should be tested to ensure correct functionality.
  */
 class SamplerBaseTest {
-    /**
-     * Extends the {@link SamplerBase} to allow access to methods.
-     */
-    @SuppressWarnings("deprecation")
-    private static class SimpleSampler extends SamplerBase {
-        SimpleSampler(UniformRandomProvider rng) {
-            super(rng);
-        }
-
-        @Override
-        public double nextDouble() {
-            return super.nextDouble();
-        }
-
-        @Override
-        public int nextInt() {
-            return super.nextInt();
-        }
-
-        @Override
-        public int nextInt(int max) {
-            return super.nextInt(max);
-        }
-
-        @Override
-        public long nextLong() {
-            return super.nextLong();
-        }
-    }
 
     @Test
     void testNextMethods() {
         final UniformRandomProvider rng1 = RandomSource.SPLIT_MIX_64.create(0L);
         final UniformRandomProvider rng2 = RandomSource.SPLIT_MIX_64.create(0L);
-        final SimpleSampler sampler = new SimpleSampler(rng2);
+        // Construct mock object
+        final SamplerBase sampler = spy(new SamplerBase(rng2));
         final int n = 256;
         for (int i = 0; i < 3; i++) {
             Assertions.assertEquals(rng1.nextDouble(), sampler.nextDouble());
@@ -73,7 +46,8 @@ class SamplerBaseTest {
     @Test
     void testToString() {
         final UniformRandomProvider rng = RandomSource.SPLIT_MIX_64.create(0L);
-        final SimpleSampler sampler = new SimpleSampler(rng);
+        // Construct mock object
+        final SamplerBase sampler = spy(new SamplerBase(rng));
         Assertions.assertTrue(sampler.toString().contains("rng"));
     }
 }


### PR DESCRIPTION
Fix [RNG-164](https://issues.apache.org/jira/browse/RNG-164)

### Description

#### Replace test class [SimpleSampler](https://github.com/apache/commons-rng/blob/42a5151f9e2433ce84a6a77299cacbc389dcb870/commons-rng-sampling/src/test/java/org/apache/commons/rng/sampling/distribution/SamplerBaseTest.java#L33) by mocking object and improve test design
<hr>

##### Motivation

- Decouple test class `SimpleSampler` from production interface `SamplerBase`.
- Remove the redundant test child class `SimpleSampler`.

<hr>

##### Key changed/added classes in this PR
 * Created mocking object to replace test subclass `SimpleSampler`, decoupled test from production code.
 * Created method that return the mocking object for code reuse.
 * Make test logic more clear by using method stub instead of method overriding.
 * Add Mockito dependency

<hr>