### PR TITLE
RNG-168: LXM family of random number generators

### DIFF
--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractL64X128.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractL64X128.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * This abstract class is a base for algorithms from the LXM family of
+ * generators with a 64-bit LCG and 128-bit XBG sub-generator. The class implements
+ * the jump and state save/restore functions.
+ *
+ * @since 1.5
+ */
+abstract class AbstractL64X128 extends AbstractXoRoShiRo128 {
+    /** LCG multiplier. */
+    protected static final long M = LXMSupport.M64;
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 4;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 2;
+
+    /** State of the LCG generator. */
+    protected long ls;
+    /** Per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    protected long la;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    AbstractL64X128(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    AbstractL64X128(long seed0, long seed1, long seed2, long seed3) {
+        super(seed0, seed1);
+        setState(seed2, seed3);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    AbstractL64X128(AbstractL64X128 source) {
+        super(source);
+        ls = source.ls;
+        la = source.la;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param s State of the LCG
+     * @param increment Increment of the LCG
+     */
+    private void setState(long s, long increment) {
+        this.ls = s;
+        // Additive parameter must be odd
+        this.la = increment | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {ls, la}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long nextOutput() {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>128</sup> - 1) positions. It can provide up to 2<sup>64</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step
+        ls = LXMSupport.M64 * ls + la;
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>32</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>32</sup> (2<sup>128</sup> - 1)
+     * positions. It can provide up to 2<sup>32</sup> non-overlapping subsequences of
+     * length 2<sup>32</sup> (2<sup>128</sup> - 1); each subsequence can provide up to
+     * 2<sup>32</sup> non-overlapping subsequences of length (2<sup>128</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^32 steps
+        ls = LXMSupport.M64P * ls + LXMSupport.C64P * la;
+        resetCachedState();
+        return copy;
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo1024.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/AbstractXoRoShiRo1024.java
@@ -49,9 +49,9 @@ abstract class AbstractXoRoShiRo1024 extends LongProvider implements LongJumpabl
         0x92a65bca41852cc1L, 0xf46820dd0509c12aL, 0x52b00c35fbf92185L, 0x1e5b3b7f589e03c1L,
     };
     /** State. */
-    private final long[] state = new long[SEED_SIZE];
+    protected final long[] state = new long[SEED_SIZE];
     /** Index in "state" array. */
-    private int index;
+    protected int index;
 
     /**
      * Creates a new instance.
@@ -191,6 +191,8 @@ abstract class AbstractXoRoShiRo1024 extends LongProvider implements LongJumpabl
                 next();
             }
         }
+        // Note: Calling the next() function updates 'index'.
+        // The present index effectively becomes 0.
         for (int j = 0; j < 16; j++) {
             state[(j + index) & 15] = newState[j];
         }

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X1024Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X1024Mix.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 128-bit LCG and 1024-bit Xor-based
+ * generator. It is named as {@code "L128X1024Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 1312 bits and the period is (2<sup>1024</sup> - 1) 2<sup>128</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 127-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L128X1024Mix extends AbstractXoRoShiRo1024 {
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 20;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 4;
+    /** Low half of 128-bit LCG multiplier. */
+    private static final long ML = LXMSupport.M128L;
+
+    /** High half of the 128-bit state of the LCG generator. */
+    private long lsh;
+    /** Low half of the 128-bit state of the LCG generator. */
+    private long lsl;
+    /** High half of the 128-bit per-instance LCG additive parameter.
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lah;
+    /** Low half of the 128-bit per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lal;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 18, only the first 18 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first 16 elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>128</sup>.
+     *
+     * <p>The 17th element is used to set the LCG state. The 18th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L128X1024Mix(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 4], seed[SEED_SIZE - 3], seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+        // Initialising to 15 ensures that (index + 1) % 16 == 0 and the
+        // first state picked from the XBG generator is state[0].
+        index = SEED_SIZE - STATE_SIZE - 1;
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L128X1024Mix(L128X1024Mix source) {
+        super(source);
+        lsh = source.lsh;
+        lsl = source.lsl;
+        lah = source.lah;
+        lal = source.lal;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param sh High half of the 128-bit state of the LCG
+     * @param sl Low half of the 128-bit state of the LCG
+     * @param ah High half of the 128-bit increment of the LCG
+     * @param al Low half of the 128-bit increment of the LCG
+     */
+    private void setState(long sh, long sl, long ah, long al) {
+        this.lsh = sh;
+        this.lsl = sl;
+        this.lah = ah;
+        // Additive parameter must be odd
+        this.lal = al | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {lsh, lsl, lah, lal}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1], state[2], state[3]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        final int q = index;
+        index = (q + 1) & 15;
+        final long s0 = state[index];
+        long s15 = state[q];
+        final long sh = lsh;
+
+        // Mix
+        final long z = LXMSupport.lea64(sh + s0);
+
+        // LCG update
+        // The LCG is, in effect, "s = m * s + a" where m = ((1LL << 64) + ML)
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+
+        // XBG update
+        s15 ^= s0;
+        state[q] = Long.rotateLeft(s0, 25) ^ s15 ^ (s15 << 27);
+        state[index] = Long.rotateLeft(s15, 36);
+
+        return z;
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long transform(long s0, long s15) {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>1024</sup> - 1) positions. It can provide up to 2<sup>128</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step.
+        final long sh = lsh;
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>64</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>64</sup> (2<sup>1024</sup> - 1)
+     * positions. It can provide up to 2<sup>64</sup> non-overlapping subsequences of
+     * length 2<sup>64</sup> (2<sup>1024</sup> - 1); each subsequence can provide up to
+     * 2<sup>64</sup> non-overlapping subsequences of length (2<sup>1024</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^64 steps
+        // Specialised routine given M128PL=1, C128PL=0 and many terms
+        // can be dropped as the low half is unchanged
+        lsh = lsh + LXMSupport.M128PH * lsl + LXMSupport.C128PH * lal;
+        resetCachedState();
+        return copy;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L128X1024Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L128X1024Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X128Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X128Mix.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 128-bit LCG and 128-bit Xor-based
+ * generator. It is named as {@code "L128X128Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 384 bits and the period is (2<sup>128</sup> - 1) 2<sup>128</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 127-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L128X128Mix extends AbstractXoRoShiRo128 {
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 6;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 4;
+    /** Low half of 128-bit LCG multiplier. */
+    private static final long ML = LXMSupport.M128L;
+
+    /** High half of the 128-bit state of the LCG generator. */
+    private long lsh;
+    /** Low half of the 128-bit state of the LCG generator. */
+    private long lsl;
+    /** High half of the 128-bit per-instance LCG additive parameter.
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lah;
+    /** Low half of the 128-bit per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lal;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 6, only the first 6 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>128</sup>.
+     *
+     * <p>The 3rd and 4th elements are used to set the LCG state.
+     * The 5th and 6th elements are used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L128X128Mix(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 4], seed[SEED_SIZE - 3], seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+    }
+
+    /**
+     * Creates a new instance using an 6 element seed.
+     * A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>128</sup>.
+     *
+     * <p>The 3rd and 4th elements are used to set the LCG state.
+     * The 5th and 6th elements are used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     */
+    public L128X128Mix(long seed0, long seed1, long seed2, long seed3,
+                       long seed4, long seed5) {
+        super(seed0, seed1);
+        setState(seed2, seed3, seed4, seed5);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L128X128Mix(L128X128Mix source) {
+        super(source);
+        lsh = source.lsh;
+        lsl = source.lsl;
+        lah = source.lah;
+        lal = source.lal;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param sh High half of the 128-bit state of the LCG
+     * @param sl Low half of the 128-bit state of the LCG
+     * @param ah High half of the 128-bit increment of the LCG
+     * @param al Low half of the 128-bit increment of the LCG
+     */
+    private void setState(long sh, long sl, long ah, long al) {
+        this.lsh = sh;
+        this.lsl = sl;
+        this.lah = ah;
+        // Additive parameter must be odd
+        this.lal = al | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {lsh, lsl, lah, lal}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1], state[2], state[3]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        final long s0 = state0;
+        final long sh = lsh;
+
+        // Mix
+        final long z = LXMSupport.lea64(sh + s0);
+
+        // LCG update
+        // The LCG is, in effect, "s = m * s + a" where m = ((1LL << 64) + ML)
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+
+        // XBG update
+        long s1 = state1;
+
+        s1 ^= s0;
+        state0 = Long.rotateLeft(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+        state1 = Long.rotateLeft(s1, 37); // c
+
+        return z;
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long nextOutput() {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>128</sup> - 1) positions. It can provide up to 2<sup>128</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step.
+        final long sh = lsh;
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>64</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>64</sup> (2<sup>128</sup> - 1)
+     * positions. It can provide up to 2<sup>64</sup> non-overlapping subsequences of
+     * length 2<sup>64</sup> (2<sup>128</sup> - 1); each subsequence can provide up to
+     * 2<sup>64</sup> non-overlapping subsequences of length (2<sup>128</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^64 steps
+        // Specialised routine given M128PL=1, C128PL=0 and many terms
+        // can be dropped as the low half is unchanged
+        lsh = lsh + LXMSupport.M128PH * lsl + LXMSupport.C128PH * lal;
+        resetCachedState();
+        return copy;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L128X128Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L128X128Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X256Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L128X256Mix.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 128-bit LCG and 256-bit Xor-based
+ * generator. It is named as {@code "L128X256Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 512 bits and the period is (2<sup>256</sup> - 1) 2<sup>128</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 127-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L128X256Mix extends AbstractXoShiRo256 {
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 8;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 4;
+    /** Low half of 128-bit LCG multiplier. */
+    private static final long ML = LXMSupport.M128L;
+
+    /** High half of the 128-bit state of the LCG generator. */
+    private long lsh;
+    /** Low half of the 128-bit state of the LCG generator. */
+    private long lsl;
+    /** High half of the 128-bit per-instance LCG additive parameter.
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lah;
+    /** Low half of the 128-bit per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long lal;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 8, only the first 8 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>128</sup>.
+     *
+     * <p>The 5th and 6th elements are used to set the LCG state.
+     * The 7th and 8th elements are used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L128X256Mix(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 4], seed[SEED_SIZE - 3], seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+    }
+
+    /**
+     * Creates a new instance using an 8 element seed.
+     * A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>128</sup>.
+     *
+     * <p>The 5th and 6th elements are used to set the LCG state.
+     * The 7th and 8th elements are used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     * @param seed6 Initial seed element 6.
+     * @param seed7 Initial seed element 7.
+     */
+    public L128X256Mix(long seed0, long seed1, long seed2, long seed3,
+                       long seed4, long seed5, long seed6, long seed7) {
+        super(seed0, seed1, seed2, seed3);
+        setState(seed4, seed5, seed6, seed7);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L128X256Mix(L128X256Mix source) {
+        super(source);
+        lsh = source.lsh;
+        lsl = source.lsl;
+        lah = source.lah;
+        lal = source.lal;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param sh High half of the 128-bit state of the LCG
+     * @param sl Low half of the 128-bit state of the LCG
+     * @param ah High half of the 128-bit increment of the LCG
+     * @param al Low half of the 128-bit increment of the LCG
+     */
+    private void setState(long sh, long sl, long ah, long al) {
+        this.lsh = sh;
+        this.lsl = sl;
+        this.lah = ah;
+        // Additive parameter must be odd
+        this.lal = al | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {lsh, lsl, lah, lal}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1], state[2], state[3]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        long s0 = state0;
+        final long sh = lsh;
+
+        // Mix
+        final long z = LXMSupport.lea64(sh + s0);
+
+        // LCG update
+        // The LCG is, in effect, "s = m * s + a" where m = ((1LL << 64) + ML)
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+
+        // XBG update
+        long s1 = state1;
+        long s2 = state2;
+        long s3 = state3;
+
+        final long t = s1 << 17;
+
+        s2 ^= s0;
+        s3 ^= s1;
+        s1 ^= s2;
+        s0 ^= s3;
+
+        s2 ^= t;
+
+        s3 = Long.rotateLeft(s3, 45);
+
+        state0 = s0;
+        state1 = s1;
+        state2 = s2;
+        state3 = s3;
+
+        return z;
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long nextOutput() {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>256</sup> - 1) positions. It can provide up to 2<sup>128</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step.
+        final long sh = lsh;
+        final long sl = lsl;
+        final long u = ML * sl;
+        // High half
+        lsh = ML * sh + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + lah;
+        // Low half
+        lsl = u + lal;
+        // Carry propagation
+        if (Long.compareUnsigned(lsl, u) < 0) {
+            ++lsh;
+        }
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>64</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>64</sup> (2<sup>256</sup> - 1)
+     * positions. It can provide up to 2<sup>64</sup> non-overlapping subsequences of
+     * length 2<sup>64</sup> (2<sup>256</sup> - 1); each subsequence can provide up to
+     * 2<sup>64</sup> non-overlapping subsequences of length (2<sup>256</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^64 steps
+        // Specialised routine given M128PL=1, C128PL=0 and many terms
+        // can be dropped as the low half is unchanged
+        lsh = lsh + LXMSupport.M128PH * lsl + LXMSupport.C128PH * lal;
+        resetCachedState();
+        return copy;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L128X256Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L128X256Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X1024Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X1024Mix.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 64-bit LCG and 1024-bit Xor-based
+ * generator. It is named as {@code "L64X1024Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 1184 bits and the period is (2<sup>1024</sup> - 1) 2<sup>64</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 63-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L64X1024Mix extends AbstractXoRoShiRo1024 {
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 18;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 2;
+    /** LCG multiplier. */
+    private static final long M = LXMSupport.M64;
+
+    /** State of the LCG generator. */
+    private long ls;
+    /** Per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long la;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 18, only the first 18 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first 16 elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 17th element is used to set the LCG state. The 18th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L64X1024Mix(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+        // Initialising to 15 ensures that (index + 1) % 16 == 0 and the
+        // first state picked from the XBG generator is state[0].
+        index = SEED_SIZE - STATE_SIZE - 1;
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L64X1024Mix(L64X1024Mix source) {
+        super(source);
+        ls = source.ls;
+        la = source.la;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param s State of the LCG
+     * @param increment Increment of the LCG
+     */
+    private void setState(long s, long increment) {
+        this.ls = s;
+        // Additive parameter must be odd
+        this.la = increment | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {ls, la}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        final int q = index;
+        index = (q + 1) & 15;
+        final long s0 = state[index];
+        long s15 = state[q];
+        final long s = ls;
+
+        // Mix
+        final long z = LXMSupport.lea64(s + s0);
+
+        // LCG update
+        ls = M * s + la;
+
+        // XBG update
+        s15 ^= s0;
+        state[q] = Long.rotateLeft(s0, 25) ^ s15 ^ (s15 << 27);
+        state[index] = Long.rotateLeft(s15, 36);
+
+
+        return z;
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long transform(long s0, long s15) {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>1024</sup> - 1) positions. It can provide up to 2<sup>64</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step
+        ls = LXMSupport.M64 * ls + la;
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>32</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>32</sup> (2<sup>1024</sup> - 1)
+     * positions. It can provide up to 2<sup>32</sup> non-overlapping subsequences of
+     * length 2<sup>32</sup> (2<sup>1024</sup> - 1); each subsequence can provide up to
+     * 2<sup>32</sup> non-overlapping subsequences of length (2<sup>1024</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^32 steps
+        ls = LXMSupport.M64P * ls + LXMSupport.C64P * la;
+        resetCachedState();
+        return copy;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L64X1024Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L64X1024Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X128Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X128Mix.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 64-bit LCG and 128-bit Xor-based
+ * generator. It is named as {@code "L64X128Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 256 bits and the period is (2<sup>128</sup> - 1) 2<sup>64</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 63-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L64X128Mix extends AbstractL64X128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L64X128Mix(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public L64X128Mix(long seed0, long seed1, long seed2, long seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L64X128Mix(L64X128Mix source) {
+        super(source);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        final long s0 = state0;
+        final long s = ls;
+
+        // Mix
+        final long z = LXMSupport.lea64(s + s0);
+
+        // LCG update
+        ls = M * s + la;
+
+        // XBG update
+        long s1 = state1;
+
+        s1 ^= s0;
+        state0 = Long.rotateLeft(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+        state1 = Long.rotateLeft(s1, 37); // c
+
+        return z;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L64X128Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L64X128Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X128StarStar.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X128StarStar.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 64-bit LCG and 128-bit Xor-based
+ * generator. It is named as {@code "L64X128StarStar"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 256 bits and the period is (2<sup>128</sup> - 1) 2<sup>64</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 63-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L64X128StarStar extends AbstractL64X128 {
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 4, only the first 4 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L64X128StarStar(long[] seed) {
+        super(seed);
+    }
+
+    /**
+     * Creates a new instance using a 4 element seed.
+     * A seed containing all zeros in the first two elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 3rd element is used to set the LCG state. The 4th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     */
+    public L64X128StarStar(long seed0, long seed1, long seed2, long seed3) {
+        super(seed0, seed1, seed2, seed3);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L64X128StarStar(L64X128StarStar source) {
+        super(source);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        final long s0 = state0;
+        final long s = ls;
+
+        // Mix
+        final long z = Long.rotateLeft((s + s0) * 5, 7) * 9;
+
+        // LCG update
+        ls = M * s + la;
+
+        // XBG update
+        long s1 = state1;
+
+        s1 ^= s0;
+        state0 = Long.rotateLeft(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+        state1 = Long.rotateLeft(s1, 37); // c
+
+        return z;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L64X128StarStar copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L64X128StarStar(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X256Mix.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/L64X256Mix.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.core.source64;
+
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.core.util.NumberFactory;
+
+/**
+ * A 64-bit all purpose generator.
+ *
+ * <p>This is a member of the LXM family of generators: L=Linear congruential generator;
+ * X=Xor based generator; and M=Mix. This member uses a 64-bit LCG and 256-bit Xor-based
+ * generator. It is named as {@code "L64X256Mix"} in the {@code java.util.random}
+ * package introduced in JDK 17; the LXM family is described in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Memory footprint is 384 bits and the period is (2<sup>256</sup> - 1) 2<sup>64</sup>.
+ *
+ * <p>This generator implements
+ * {@link org.apache.commons.rng.LongJumpableUniformRandomProvider LongJumpableUniformRandomProvider}.
+ * In addition instances created with a different additive parameter for the LCG are robust
+ * against accidental correlation in a multi-threaded setting. The additive parameters must be
+ * different in the most significant 63-bits.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/package-summary.html">
+ *      JDK 17 java.util.random javadoc</a>
+ * @since 1.5
+ */
+public class L64X256Mix extends AbstractXoShiRo256 {
+    /** Size of the seed vector. */
+    private static final int SEED_SIZE = 6;
+    /** Size of the state vector. */
+    private static final int STATE_SIZE = 2;
+    /** LCG multiplier. */
+    private static final long M = LXMSupport.M64;
+
+    /** State of the LCG generator. */
+    private long ls;
+    /** Per-instance LCG additive parameter (must be odd).
+     * Cannot be final to support RestorableUniformRandomProvider. */
+    private long la;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param seed Initial seed.
+     * If the length is larger than 6, only the first 6 elements will
+     * be used; if smaller, the remaining elements will be automatically
+     * set. A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 5th element is used to set the LCG state. The 6th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     */
+    public L64X256Mix(long[] seed) {
+        // Ensure seed is expanded only once
+        super(seed = LXMSupport.ensureSeedLength(seed, SEED_SIZE));
+        setState(seed[SEED_SIZE - 2], seed[SEED_SIZE - 1]);
+    }
+
+    /**
+     * Creates a new instance using a 6 element seed.
+     * A seed containing all zeros in the first four elements
+     * will create a non-functional XBG sub-generator and a low
+     * quality output with a period of 2<sup>64</sup>.
+     *
+     * <p>The 5th element is used to set the LCG state. The 6th element is used
+     * to set the LCG increment; the least significant bit
+     * is set to odd to ensure a full period LCG.</p>
+     *
+     * @param seed0 Initial seed element 0.
+     * @param seed1 Initial seed element 1.
+     * @param seed2 Initial seed element 2.
+     * @param seed3 Initial seed element 3.
+     * @param seed4 Initial seed element 4.
+     * @param seed5 Initial seed element 5.
+     */
+    public L64X256Mix(long seed0, long seed1, long seed2, long seed3,
+                      long seed4, long seed5) {
+        super(seed0, seed1, seed2, seed3);
+        setState(seed4, seed5);
+    }
+
+    /**
+     * Creates a copy instance.
+     *
+     * @param source Source to copy.
+     */
+    protected L64X256Mix(L64X256Mix source) {
+        super(source);
+        ls = source.ls;
+        la = source.la;
+    }
+
+    /**
+     * Copies the state into the generator state.
+     *
+     * @param s State of the LCG
+     * @param increment Increment of the LCG
+     */
+    private void setState(long s, long increment) {
+        this.ls = s;
+        // Additive parameter must be odd
+        this.la = increment | 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected byte[] getStateInternal() {
+        return composeStateInternal(NumberFactory.makeByteArray(new long[] {ls, la}),
+                                    super.getStateInternal());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void setStateInternal(byte[] s) {
+        final byte[][] c = splitStateInternal(s, STATE_SIZE * Long.BYTES);
+
+        final long[] state = NumberFactory.makeLongArray(c[0]);
+        setState(state[0], state[1]);
+
+        super.setStateInternal(c[1]);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long next() {
+        // LXM generate.
+        // Old state is used for the output allowing parallel pipelining
+        // on processors that support multiple concurrent instructions.
+
+        long s0 = state0;
+        final long s = ls;
+
+        // Mix
+        final long z = LXMSupport.lea64(s + s0);
+
+        // LCG update
+        ls = M * s + la;
+
+        // XBG update
+        long s1 = state1;
+        long s2 = state2;
+        long s3 = state3;
+
+        final long t = s1 << 17;
+
+        s2 ^= s0;
+        s3 ^= s1;
+        s1 ^= s2;
+        s0 ^= s3;
+
+        s2 ^= t;
+
+        s3 = Long.rotateLeft(s3, 45);
+
+        state0 = s0;
+        state1 = s1;
+        state2 = s2;
+        state3 = s3;
+
+        return z;
+    }
+
+    /** Unsupported. The LXM algorithm redefines the next() method. */
+    @Override
+    protected long nextOutput() {
+        throw new UnsupportedOperationException("The LXM algorithm redefines the next() method");
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by 1 cycle.
+     * The XBG state is unchanged. The jump size is the equivalent of moving the state
+     * <em>backwards</em> by (2<sup>256</sup> - 1) positions. It can provide up to 2<sup>64</sup>
+     * non-overlapping subsequences.</p>
+     */
+    @Override
+    public UniformRandomProvider jump() {
+        final UniformRandomProvider copy = copy();
+        // Advance the LCG 1 step
+        ls = M * ls + la;
+        resetCachedState();
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the UniformRandomProvider and then <em>retreats</em> the state of the
+     * current instance. The copy is returned.
+     *
+     * <p>The jump is performed by advancing the state of the LCG sub-generator by
+     * 2<sup>32</sup> cycles. The XBG state is unchanged. The jump size is the equivalent
+     * of moving the state <em>backwards</em> by 2<sup>32</sup> (2<sup>256</sup> - 1)
+     * positions. It can provide up to 2<sup>32</sup> non-overlapping subsequences of
+     * length 2<sup>32</sup> (2<sup>256</sup> - 1); each subsequence can provide up to
+     * 2<sup>32</sup> non-overlapping subsequences of length (2<sup>256</sup> - 1) using
+     * the {@link #jump()} method.</p>
+     */
+    @Override
+    public JumpableUniformRandomProvider longJump() {
+        final JumpableUniformRandomProvider copy = copy();
+        // Advance the LCG 2^32 steps
+        ls = LXMSupport.M64P * ls + LXMSupport.C64P * la;
+        resetCachedState();
+        return copy;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected L64X256Mix copy() {
+        // This exists to ensure the jump function performed in the super class returns
+        // the correct class type. It should not be public.
+        return new L64X256Mix(this);
+    }
+}

--- a/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/LXMSupport.java
+++ b/commons-rng-core/src/main/java/org/apache/commons/rng/core/source64/LXMSupport.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.Arrays;
+
+/**
+ * Utility support for the LXM family of generators. The LXM family is described
+ * in further detail in:
+ *
+ * <blockquote>Steele and Vigna (2021) LXM: better splittable pseudorandom number generators
+ * (and almost as fast). Proceedings of the ACM on Programming Languages, Volume 5,
+ * Article 148, pp 1–31.</blockquote>
+ *
+ * <p>Contains methods to compute unsigned multiplication of 64-bit
+ * and 128-bit values to create 128-bit results for use in a 128-bit
+ * linear congruential generator (LCG). Methods are provided to advance the state
+ * of an LCG by a power of 2 in a single multiply operation to support jump
+ * operations.
+ *
+ * @see <a href="https://doi.org/10.1145/3485525">Steele &amp; Vigna (2021) Proc. ACM Programming
+ *      Languages 5, 1-31</a>
+ */
+final class LXMSupport {
+    /** 64-bit LCG multiplier. Note: (M % 8) = 5. */
+    static final long M64 = 0xd1342543de82ef95L;
+    /** Jump constant {@code m'} for an advance of the 64-bit LCG by 2^32.
+     * The value is {@code m^(2^32)}. */
+    static final long M64P = 0x8d23804c00000001L;
+    /** Jump constant precursor for {@code c'} for an advance of the 64-bit LCG by 2^32.
+     * The value is:
+     * <pre>
+     * product { M^(2^i) + 1 },  i in [0, 31]
+     * </pre>
+     * <p>The jump is computed for the LCG {@code s = m * s + c} as:
+     * <pre>
+     * s = m' * s + c' * c
+     * </pre>
+     */
+    static final long C64P = 0x16691c9700000000L;
+
+    /** Low half of 128-bit LCG multiplier. The upper half is {@code 1L}. */
+    static final long M128L = 0xd605bbb58c8abbfdL;
+    /** High half of the jump constant {@code m'} for an advance of the 128-bit LCG by 2^64.
+     * The low half is 1. The value is {@code m^(2^64)}. */
+    static final long M128PH = 0x31f179f5224754f4L;
+    /** High half of the jump constant for an advance of the 128-bit LCG by 2^64.
+     * The low half is zero. The value is:
+     * <pre>
+     * product { M^(2^i) + 1 },  i in [0, 63]
+     * </pre>
+     * <p>The jump is computed for the LCG {@code s = m * s + c} as:
+     * <pre>
+     * s = m' * s + c' * c
+     * </pre>
+     */
+    static final long C128PH = 0x61139b28883277c3L;
+
+    /**
+     * The fractional part of the the golden ratio, phi, scaled to 64-bits and rounded to odd.
+     * <pre>
+     * phi = (sqrt(5) - 1) / 2) * 2^64
+     * </pre>
+     * @see <a href="https://en.wikipedia.org/wiki/Golden_ratio">Golden ratio</a>
+     */
+    private static final long GOLDEN_RATIO = 0x9e3779b97f4a7c15L;
+    /** A mask to convert an {@code int} to an unsigned integer stored as a {@code long}. */
+    private static final long INT_TO_UNSIGNED_BYTE_MASK = 0xffffffffL;
+
+    /** No instances. */
+    private LXMSupport() {}
+
+    /**
+     * Ensure the seed is at least the specified minimum length.
+     *
+     * <p>This method can be used in constructors that must pass their seed to the super class
+     * to avoid a duplication of seed expansion to the minimum length required by the super class
+     * and the class:
+     * <pre>
+     * public RNG extends AnotherRNG {
+     *     public RNG(long[] seed) {
+     *         super(seed = LXMSupport.ensureSeedLength(seed, 123));
+     *         // Use seed for additional state
+     *     }
+     * }
+     * </pre>
+     *
+     * <p>Note using the state filling procedure provided in
+     * {@link org.apache.commons.rng.core.BaseProvider BaseProvider} is not possible as it
+     * is an instance method. Calling a seed expansion routine must use a static method.
+     *
+     * <p>This method functions as if the seed has been expanded using a {@link SplitMix64}
+     * generator seeded with the {@code seed[0]}, or zero if the input seed length is zero.
+     * <pre>
+     * if (seed.length < length) {
+     *     final long[] s = Arrays.copyOf(seed, length);
+     *     final SplitMix64 rng = new SplitMix64(s[0]);
+     *     for (int i = seed.length; i < length; i++) {
+     *         s[i] = rng.nextLong();
+     *     }
+     *     return s;
+     * }
+     * </pre>
+     *
+     * @param seed Input seed
+     * @param length The minimum length
+     * @return the seed
+     */
+    static long[] ensureSeedLength(long[] seed, int length) {
+        if (seed.length < length) {
+            final long[] s = Arrays.copyOf(seed, length);
+            // Fill the rest as if using a SplitMix64 RNG
+            long x = s[0];
+            for (int i = seed.length; i < length; i++) {
+                s[i] = stafford13(x += GOLDEN_RATIO);
+            }
+            return s;
+        }
+        return seed;
+    }
+
+    /**
+     * Perform variant 13 of David Stafford's 64-bit mix function.
+     * This is the mix function used in the {@link SplitMix64} RNG.
+     *
+     * <p>This is ranked first of the top 14 Stafford mixers.
+     *
+     * @param x the input value
+     * @return the output value
+     * @see <a href="http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html">Better
+     *      Bit Mixing - Improving on MurmurHash3&#39;s 64-bit Finalizer.</a>
+     */
+    private static long stafford13(long x) {
+        x = (x ^ (x >>> 30)) * 0xbf58476d1ce4e5b9L;
+        x = (x ^ (x >>> 27)) * 0x94d049bb133111ebL;
+        return x ^ (x >>> 31);
+    }
+
+    /**
+     * Perform a 64-bit mixing function using Doug Lea's 64-bit mix constants and shifts.
+     *
+     * <p>This is based on the original 64-bit mix function of Austin Appleby's
+     * MurmurHash3 modified to use a single mix constant and 32-bit shifts, which may have
+     * a performance advantage on some processors. The code is provided in Steele and
+     * Vigna's paper.
+     *
+     * @param x the input value
+     * @return the output value
+     */
+    static long lea64(long x) {
+        x = (x ^ (x >>> 32)) * 0xdaba0b6eb09322e3L;
+        x = (x ^ (x >>> 32)) * 0xdaba0b6eb09322e3L;
+        return x ^ (x >>> 32);
+    }
+
+    /**
+     * Multiply the two values as if unsigned 64-bit longs to produce the high 64-bits
+     * of the 128-bit unsigned result.
+     *
+     * <p>This method computes the equivalent of:
+     * <pre>
+     * Math.multiplyHigh(a, b) + ((a >> 63) & b) + ((b >> 63) & a)
+     * </pre>
+     *
+     * <p>Note: The method {@code Math.multiplyHigh} was added in JDK 9
+     * and should be used as above when the source code targets Java 11
+     * to exploit the intrinsic method.
+     *
+     * <p>Note: The method {@code Math.unsignedMultiplyHigh} was added in JDK 18
+     * and should be used when the source code target allows.
+     *
+     * @param value1 the first value
+     * @param value2 the second value
+     * @return the high 64-bits of the 128-bit result
+     */
+    static long unsignedMultiplyHigh(long value1, long value2) {
+        // Computation is based on the following observation about the upper (a and x)
+        // and lower (b and y) bits of unsigned big-endian integers:
+        //   ab * xy
+        // =  b *  y
+        // +  b * x0
+        // + a0 *  y
+        // + a0 * x0
+        // = b * y
+        // + b * x * 2^32
+        // + a * y * 2^32
+        // + a * x * 2^64
+        //
+        // Summation using a character for each byte:
+        //
+        //             byby byby
+        // +      bxbx bxbx 0000
+        // +      ayay ayay 0000
+        // + axax axax 0000 0000
+        //
+        // The summation can be rearranged to ensure no overflow given
+        // that the result of two unsigned 32-bit integers multiplied together
+        // plus two full 32-bit integers cannot overflow 64 bits:
+        // > long x = (1L << 32) - 1
+        // > x * x + x + x == -1 (all bits set, no overflow)
+        //
+        // The carry is a composed intermediate which will never overflow:
+        //
+        //             byby byby
+        // +           bxbx 0000
+        // +      ayay ayay 0000
+        //
+        // +      bxbx 0000 0000
+        // + axax axax 0000 0000
+
+        final long a = value1 >>> 32;
+        final long b = value1 & INT_TO_UNSIGNED_BYTE_MASK;
+        final long x = value2 >>> 32;
+        final long y = value2 & INT_TO_UNSIGNED_BYTE_MASK;
+
+
+        final long by = b * y;
+        final long bx = b * x;
+        final long ay = a * y;
+        final long ax = a * x;
+
+        // Cannot overflow
+        final long carry = (by >>> 32) +
+                           (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                            ay;
+        // Note:
+        // low = (carry << 32) | (by & INT_TO_UNSIGNED_BYTE_MASK)
+        // Benchmarking shows outputting low to a long[] output argument
+        // has no benefit over computing 'low = value1 * value2' separately.
+
+        return (bx >>> 32) + (carry >>> 32) + ax;
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/ProvidersList.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/ProvidersList.java
@@ -61,6 +61,13 @@ import org.apache.commons.rng.core.source64.XoShiRo512Plus;
 import org.apache.commons.rng.core.source64.XoShiRo512PlusPlus;
 import org.apache.commons.rng.core.source64.XoShiRo512StarStar;
 import org.apache.commons.rng.core.source64.JenkinsSmallFast64;
+import org.apache.commons.rng.core.source64.L128X1024Mix;
+import org.apache.commons.rng.core.source64.L128X128Mix;
+import org.apache.commons.rng.core.source64.L128X256Mix;
+import org.apache.commons.rng.core.source64.L64X1024Mix;
+import org.apache.commons.rng.core.source64.L64X128Mix;
+import org.apache.commons.rng.core.source64.L64X128StarStar;
+import org.apache.commons.rng.core.source64.L64X256Mix;
 import org.apache.commons.rng.core.source64.MersenneTwister64;
 import org.apache.commons.rng.core.source64.PcgRxsMXs64;
 import org.apache.commons.rng.core.source64.DotyHumphreySmallFastCounting64;
@@ -143,6 +150,13 @@ public final class ProvidersList {
             LIST64.add(new XoRoShiRo1024PlusPlus(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
             LIST64.add(new XoRoShiRo1024Star(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
             LIST64.add(new XoRoShiRo1024StarStar(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L64X128StarStar(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L64X128Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L64X256Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L64X1024Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L128X128Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L128X256Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
+            LIST64.add(new L128X1024Mix(new long[] {g.nextLong(), g.nextLong(), g.nextLong(), g.nextLong()}));
             // ... add more here.
 
             // Do not modify the remaining statements.

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/AbstractLXMTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/AbstractLXMTest.java
@@ -1,0 +1,1206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.math.BigInteger;
+import java.util.SplittableRandom;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.RestorableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Base test for LXM generators. These generators all use the same basic steps:
+ * <pre>
+ * s = state of LCG
+ * t = state of XBG
+ *
+ * generate():
+ *    z <- mix(combine(w upper bits of s, w upper bits of t))
+ *    s <- LCG state update
+ *    t <- XBG state update
+ * </pre>
+ *
+ * <p>This base class provides a composite generator of an LCG and XBG
+ * both using w = 64-bits. Tests for a RNG implementation must define
+ * a factory for constructing a reference composite LXM generator. Implementations
+ * for the 64-bit and 128-bit LCG used in the LXM family are provided.
+ * Implementations for the XBG are provided based on version in the Commons RNG core library.
+ *
+ * <p>It is assumed the XBG generator is a {@link LongJumpableUniformRandomProvider}.
+ * The composite generator requires the sub-generators to provide a jump and long jump
+ * equivalent operation. This is performed by advancing/rewinding the LCG and XBG the same number
+ * of cycles. In practice this is performed using:
+ * <ul>
+ * <li>A large jump of the XBG that wraps the state of the LCG.
+ * <li>Leaving the XBG state unchanged and advancing the LCG. This effectively
+ * rewinds the state of the LXM by the period of the XBG multiplied by the number of
+ * cycles advanced by the LCG.
+ * </ul>
+ *
+ * <p>The paper by Steele and Vigna suggest advancing the LCG to take advantage of the fast
+ * update step of the LCG. This is particularly true for the 64-bit LCG variants. If
+ * the LCG and XBG sub-generators support jump/longJump then the composite can then be
+ * used to test arbitrary combinations of calls to: generate the next long value; and jump
+ * operations. This is not possible using the reference implementations of the LXM family
+ * in JDK 17 which do not implement jumping (instead providing a split operation to create
+ * new RNGs).
+ *
+ * <p>The test assumes the following conditions:
+ * <ul>
+ * <li>The seed length equals the state size of the XBG and LCG generators.
+ * <li>The LXM generator seed is the seed for the XBG appended with the seed for the LCG.
+ * <li>The LCG seed in order is [initial state, additive parameter]. The additive parameter
+ * must be odd for a maximum period LCG and the test asserts the final bit of the seed is
+ * effectively ignored as it is forced to be odd in the constructor.
+ * <li>If the XBG seed is all zeros, the LXM generator is partially functional. It will output
+ * non-zero values but the sequence may be statistically weak and the period is that of the LCG.
+ * This cannot be practically tested but non-zero output is verified for an all zero seed.
+ * </ul>
+ *
+ * <p>The class uses a per-class lifecycle. This allows abstract methods to be overridden
+ * in implementing classes to control test behaviour.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+abstract class AbstractLXMTest {
+    /**
+     * A function to mix two long values.
+     * Implements the combine and mix functions of the LXM generator.
+     */
+    interface Mix {
+        /**
+         * Mix the values.
+         *
+         * @param a Value a
+         * @param b Value b
+         * @return the result
+         */
+        long apply(long a, long b);
+    }
+
+    /**
+     * A jumpable sub-generator. This can be a linear congruential generator (LCG)
+     * or xor-based generator (XBG) when used in the LXM family.
+     */
+    interface SubGen {
+        /**
+         * Get the upper 64-bits of the state.
+         *
+         * @return the state
+         */
+        long state();
+
+        /**
+         * Update the state
+         */
+        void update();
+
+        /**
+         * Return the current state and update the state.
+         *
+         * @return the state
+         */
+        default long stateAndUpdate() {
+            final long s = state();
+            update();
+            return s;
+        }
+
+        /**
+         * Create a copy and then advance the state in a single jump; the copy is returned.
+         *
+         * @return the copy
+         */
+        SubGen copyAndJump();
+
+        /**
+         * Create a copy and then advance the state in a single long jump; the copy is returned.
+         *
+         * @return the copy
+         */
+        SubGen copyAndLongJump();
+    }
+
+    /**
+     * Mix the sum using the star star function.
+     *
+     * @param a Value a
+     * @param b Value b
+     * @return the result
+     */
+    static long mixStarStar(long a, long b) {
+        return Long.rotateLeft((a + b) * 5, 7) * 9;
+    }
+
+    /**
+     * Mix the sum using the lea64 function.
+     *
+     * @param a Value a
+     * @param b Value b
+     * @return the result
+     */
+    static long mixLea64(long a, long b) {
+        return LXMSupport.lea64(a + b);
+    }
+
+    /**
+     * A 64-bit linear congruential generator.
+     */
+    static class LCG64 implements SubGen {
+        /** Multiplier. */
+        private static final long M = LXMSupport.M64;
+        /** State. */
+        private long s;
+        /** Additive parameter (must be odd). */
+        private final long a;
+        /** Power of 2 for the jump. */
+        private final int jumpPower;
+        /** Power of 2 for the long jump. */
+        private final int longJumpPower;
+
+        /**
+         * Create an instance with a jump of 1 cycle and long jump of 2^32 cycles.
+         *
+         * @param s State
+         * @param a Additive parameter (set to odd)
+         */
+        LCG64(long s, long a) {
+            this(s, a, 0, 32);
+        }
+
+        /**
+         * @param s State
+         * @param a Additive parameter (set to odd)
+         * @param jumpPower Jump size as a power of 2
+         * @param longJumpPower Long jump size as a power of 2
+         */
+        LCG64(long s, long a, int jumpPower, int longJumpPower) {
+            this.s = s;
+            this.a = a | 1;
+            this.jumpPower = jumpPower;
+            this.longJumpPower = longJumpPower;
+        }
+
+        @Override
+        public long state() {
+            return s;
+        }
+
+        @Override
+        public void update() {
+            s = M * s + a;
+        }
+
+        @Override
+        public SubGen copyAndJump() {
+            final SubGen copy = new LCG64(s, a, jumpPower, longJumpPower);
+            s = LXMSupportTest.lcgAdvancePow2(s, M, a, jumpPower);
+            return copy;
+        }
+
+        @Override
+        public SubGen copyAndLongJump() {
+            final SubGen copy = new LCG64(s, a, jumpPower, longJumpPower);
+            s = LXMSupportTest.lcgAdvancePow2(s, M, a, longJumpPower);
+            return copy;
+        }
+    }
+
+    /**
+     * A 128-bit linear congruential generator.
+     */
+    static class LCG128 implements SubGen {
+        /** Low half of 128-bit multiplier. The upper half is 1. */
+        private static final long ML = LXMSupport.M128L;
+        /** High bits of state. */
+        private long sh;
+        /** Low bits of state. */
+        private long sl;
+        /** High bits of additive parameter. */
+        private final long ah;
+        /** Low bits of additive parameter (must be odd). */
+        private final long al;
+        /** Power of 2 for the jump. */
+        private final int jumpPower;
+        /** Power of 2 for the long jump. */
+        private final int longJumpPower;
+
+        /**
+         * Create an instance with a jump of 1 cycle and long jump of 2^64 cycles.
+         *
+         * @param sh High bits of the 128-bit state
+         * @param sl Low bits of the 128-bit state
+         * @param ah High bits of additive parameter
+         * @param al Low bits of additive parameter (set to odd)
+         */
+        LCG128(long sh, long sl, long ah, long al) {
+            this(sh, sl, ah, al, 0, 64);
+        }
+
+        /**
+         * @param sh High bits of the 128-bit state
+         * @param sl Low bits of the 128-bit state
+         * @param ah High bits of additive parameter
+         * @param al Low bits of additive parameter (set to odd)
+         * @param jumpPower Jump size as a power of 2
+         * @param longJumpPower Long jump size as a power of 2
+         */
+        LCG128(long sh, long sl, long ah, long al, int jumpPower, int longJumpPower) {
+            this.sh = sh;
+            this.sl = sl;
+            this.ah = ah;
+            this.al = al | 1;
+            this.jumpPower = jumpPower;
+            this.longJumpPower = longJumpPower;
+        }
+
+        @Override
+        public long state() {
+            return sh;
+        }
+
+        @Override
+        public void update() {
+            // The LCG is, in effect, "s = m * s + a" where m = ((1LL << 64) + ML)
+            final long u = ML * sl;
+            // High half
+            sh = (ML * sh) + LXMSupport.unsignedMultiplyHigh(ML, sl) + sl + ah;
+            // Low half
+            sl = u + al;
+            // Carry propagation
+            if (Long.compareUnsigned(sl, u) < 0) {
+                ++sh;
+            }
+        }
+
+        @Override
+        public SubGen copyAndJump() {
+            final SubGen copy = new LCG128(sh, sl, ah, al, jumpPower, longJumpPower);
+            final long nsl = LXMSupportTest.lcgAdvancePow2(sl, ML, al, jumpPower);
+            sh = LXMSupportTest.lcgAdvancePow2High(sh, sl, 1, ML, ah, al, jumpPower);
+            sl = nsl;
+            return copy;
+        }
+
+        @Override
+        public SubGen copyAndLongJump() {
+            final SubGen copy = new LCG128(sh, sl, ah, al, jumpPower, longJumpPower);
+            final long nsl = LXMSupportTest.lcgAdvancePow2(sl, ML, al, longJumpPower);
+            sh = LXMSupportTest.lcgAdvancePow2High(sh, sl, 1, ML, ah, al, longJumpPower);
+            sl = nsl;
+            return copy;
+        }
+    }
+
+    /**
+     * A xor-based generator using XoRoShiRo128.
+     *
+     * <p>The generator can be configured to perform jumps or simply return a copy.
+     * The LXM generator would jump by advancing only the LCG state.
+     */
+    static class XBGXoRoShiRo128 extends AbstractXoRoShiRo128 implements SubGen {
+        /** Jump flag. */
+        private final boolean jump;
+
+        /**
+         * Create an instance with jumping enabled.
+         *
+         * @param seed seed
+         */
+        XBGXoRoShiRo128(long[] seed) {
+            super(seed);
+            jump = true;
+        }
+
+        /**
+         * @param seed0 seed element 0
+         * @param seed1 seed element 1
+         * @param jump Set to true to perform jumping, otherwise a jump returns a copy
+         */
+        XBGXoRoShiRo128(long seed0, long seed1, boolean jump) {
+            super(seed0, seed1);
+            this.jump = jump;
+        }
+
+        /**
+         * Copy constructor.
+         *
+         * @param source the source to copy
+         */
+        XBGXoRoShiRo128(XBGXoRoShiRo128 source) {
+            super(source);
+            jump = source.jump;
+        }
+
+        @Override
+        public long state() {
+            return state0;
+        }
+
+        @Override
+        public void update() {
+            next();
+        }
+
+        @Override
+        public SubGen copyAndJump() {
+            return (SubGen) (jump ? super.jump() : copy());
+        }
+
+        @Override
+        public SubGen copyAndLongJump() {
+            return (SubGen) (jump ? super.longJump() : copy());
+        }
+
+        @Override
+        protected long nextOutput() {
+            // Not used
+            return 0;
+        }
+
+        @Override
+        protected XBGXoRoShiRo128 copy() {
+            return new XBGXoRoShiRo128(this);
+        }
+    }
+
+    /**
+     * A xor-based generator using XoShiRo256.
+     *
+     * <p>The generator can be configured to perform jumps or simply return a copy.
+     * The LXM generator would jump by advancing only the LCG state.
+     */
+    static class XBGXoShiRo256 extends AbstractXoShiRo256 implements SubGen {
+        /** Jump flag. */
+        private final boolean jump;
+
+        /**
+         * Create an instance with jumping enabled.
+         *
+         * @param seed seed
+         */
+        XBGXoShiRo256(long[] seed) {
+            super(seed);
+            jump = true;
+        }
+
+        /**
+         * @param seed0 seed element 0
+         * @param seed1 seed element 1
+         * @param seed2 seed element 2
+         * @param seed3 seed element 3
+         * @param jump Set to true to perform jumping, otherwise a jump returns a copy
+         */
+        XBGXoShiRo256(long seed0, long seed1, long seed2, long seed3, boolean jump) {
+            super(seed0, seed1, seed2, seed3);
+            this.jump = jump;
+        }
+
+        /**
+         * Copy constructor.
+         *
+         * @param source the source to copy
+         */
+        XBGXoShiRo256(XBGXoShiRo256 source) {
+            super(source);
+            jump = source.jump;
+        }
+
+        @Override
+        public long state() {
+            return state0;
+        }
+
+        @Override
+        public void update() {
+            next();
+        }
+
+        @Override
+        public SubGen copyAndJump() {
+            return (SubGen) (jump ? super.jump() : copy());
+        }
+
+        @Override
+        public SubGen copyAndLongJump() {
+            return (SubGen) (jump ? super.longJump() : copy());
+        }
+
+        @Override
+        protected long nextOutput() {
+            // Not used
+            return 0;
+        }
+
+        @Override
+        protected XBGXoShiRo256 copy() {
+            return new XBGXoShiRo256(this);
+        }
+    }
+
+    /**
+     * A xor-based generator using XoRoShiRo1024.
+     *
+     * <p>The generator can be configured to perform jumps or simply return a copy.
+     * The LXM generator would jump by advancing only the LCG state.
+     */
+    static class XBGXoRoShiRo1024 extends AbstractXoRoShiRo1024 implements SubGen {
+        /** Jump flag. */
+        private final boolean jump;
+
+        /**
+         * Create an instance with jumping enabled.
+         *
+         * @param seed 16-element seed
+         */
+        XBGXoRoShiRo1024(long[] seed) {
+            this(seed, true);
+        }
+
+        /**
+         * @param seed 16-element seed
+         * @param jump Set to true to perform jumping, otherwise a jump returns a copy
+         */
+        XBGXoRoShiRo1024(long[] seed, boolean jump) {
+            super(seed);
+            // Ensure the first state returned corresponds to state[0]
+            index = state.length - 1;
+            this.jump = jump;
+        }
+
+        /**
+         * Copy constructor.
+         *
+         * @param source the source to copy
+         */
+        XBGXoRoShiRo1024(XBGXoRoShiRo1024 source) {
+            super(source);
+            jump = source.jump;
+        }
+
+        @Override
+        public long state() {
+            // The target state is 1 ahead of the current index.
+            // This is the value s0 that will be passed to transform(s0, s15).
+            return state[(index + 1) & 15];
+        }
+
+        @Override
+        public void update() {
+            next();
+        }
+
+        @Override
+        public SubGen copyAndJump() {
+            return (SubGen) (jump ? super.jump() : copy());
+        }
+
+        @Override
+        public SubGen copyAndLongJump() {
+            return (SubGen) (jump ? super.longJump() : copy());
+        }
+
+        @Override
+        protected long transform(long s0, long s15) {
+            // Not used
+            return 0;
+        }
+
+        @Override
+        protected XBGXoRoShiRo1024 copy() {
+            return new XBGXoRoShiRo1024(this);
+        }
+    }
+
+    /**
+     * A composite LXM generator. Implements:
+     * <pre>
+     * s = state of LCG
+     * t = state of XBG
+     *
+     * generate():
+     *    z <- mix(combine(w upper bits of s, w upper bits of t))
+     *    s <- LCG state update
+     *    t <- XBG state update
+     * </pre>
+     * <p>w is assumed to be 64-bits.
+     */
+    static class LXMGenerator extends LongProvider implements LongJumpableUniformRandomProvider {
+        /** Mix implementation. */
+        private final Mix mix;
+        /** LCG implementation. */
+        private final SubGen lcg;
+        /** XBG implementation. */
+        private final SubGen xbg;
+
+        /**
+         * Create a new instance.
+         * The jump and long jump of the LCG are assumed to appropriately match those of the XBG.
+         * This can be achieved by an XBG jump that wraps the period of the LCG; or advancing
+         * the LCG and leaving the XBG state unchanged, effectively rewinding the LXM generator.
+         *
+         * @param mix Mix implementation
+         * @param lcg LCG implementation
+         * @param xbg XBG implementation
+         */
+        LXMGenerator(Mix mix, SubGen lcg, SubGen xbg) {
+            this.lcg = lcg;
+            this.xbg = xbg;
+            this.mix = mix;
+        }
+
+        @Override
+        public long next() {
+            final long z = mix.apply(lcg.state(), xbg.state());
+            lcg.update();
+            xbg.update();
+            return z;
+        }
+
+        @Override
+        public LXMGenerator jump() {
+            return new LXMGenerator(mix, lcg.copyAndJump(), xbg.copyAndJump());
+        }
+
+        @Override
+        public LXMGenerator longJump() {
+            return new LXMGenerator(mix, lcg.copyAndLongJump(), xbg.copyAndLongJump());
+        }
+    }
+
+    /**
+     * A factory for creating LXMGenerator objects.
+     */
+    interface LXMGeneratorFactory {
+        /**
+         * Return the size of the LCG long seed array.
+         *
+         * @return the LCG seed size
+         */
+        int lcgSeedSize();
+
+        /**
+         * Return the size of the XBG long seed array.
+         *
+         * @return the XBG seed size
+         */
+        int xbgSeedSize();
+
+        /**
+         * Return the size of the long seed array.
+         * The default implementation adds the size of the LCG and XBG seed.
+         *
+         * @return the seed size
+         */
+        default int seedSize() {
+            return lcgSeedSize() + xbgSeedSize();
+        }
+
+        /**
+         * Creates a new LXMGenerator.
+         *
+         * <p>Tests using the LXMGenerator assume the seed is a composite containing the
+         * XBG seed and then the LCG seed.
+         *
+         * @param seed the seed
+         * @return the generator
+         */
+        LXMGenerator create(long[] seed);
+
+        /**
+         * Gets the mix implementation. This is used to test initial output of the generator.
+         * The default implementation is {@link AbstractLXMTest#mixLea64(long, long)}.
+         *
+         * @return the mix
+         */
+        default Mix getMix() {
+            return AbstractLXMTest::mixLea64;
+        }
+    }
+
+    /**
+     * Test the LCG implementations. These tests should execute only once, and not
+     * for each instance of the abstract outer class (i.e. the test is not {@code @Nested}).
+     *
+     * <p>Note: The LCG implementation are not present in the main RNG core package and
+     * this test ensures an LCG update of:
+     * <pre>
+     * s = m * s + a
+     *
+     * s = state
+     * m = multiplier
+     * a = addition
+     * </pre>
+     *
+     * <p>A test is made to ensure the LCG can perform jump and long jump operations using
+     * small jumps that can be verified by an equal number of single state updates.
+     */
+    static class LCGTest {
+        /** 2^63. */
+        private static final BigInteger TWO_POW_63 = BigInteger.ONE.shiftLeft(63);
+        /** 65-bit multiplier for the 128-bit LCG. */
+        private static final BigInteger M = BigInteger.ONE.shiftLeft(64).add(toUnsignedBigInteger(LXMSupport.M128L));
+        /** 2^128. Used as the modulus for the 128-bit LCG. */
+        private static final BigInteger MOD = BigInteger.ONE.shiftLeft(128);
+        /** A count {@code k} where a jump of {@code 2^k} will wrap the LCG state. */
+        private static final int NO_JUMP = -1;
+        /** A count {@code k=2} for a jump of {@code 2^k}, or 4 cycles. */
+        private static final int JUMP = 2;
+        /** A count {@code k=4} for a long jump of {@code 2^k}, or 16 cycles. */
+        private static final int LONG_JUMP = 4;
+
+        @RepeatedTest(value = 10)
+        void testLCG64() {
+            final SplittableRandom rng = new SplittableRandom();
+            final long state = rng.nextLong();
+            final long add = rng.nextLong();
+            long s = state;
+            final long a = add | 1;
+            final SubGen lcg = new LCG64(state, add, NO_JUMP, NO_JUMP);
+            for (int j = 0; j < 10; j++) {
+                Assertions.assertEquals(s, lcg.stateAndUpdate(),
+                    () -> String.format("seed %d,%d", state, add));
+                s = LXMSupport.M64 * s + a;
+            }
+        }
+
+        @RepeatedTest(value = 10)
+        void testLCG64Jump() {
+            final SplittableRandom rng = new SplittableRandom();
+            final long state = rng.nextLong();
+            final long add = rng.nextLong();
+            final Supplier<String> msg = () -> String.format("seed %d,%d", state, add);
+            long s = state;
+            final long a = add | 1;
+            final SubGen lcg = new LCG64(state, add, JUMP, LONG_JUMP);
+
+            final SubGen lcg1 = lcg.copyAndJump();
+            for (int j = 1 << JUMP; j-- != 0;) {
+                Assertions.assertEquals(s, lcg1.stateAndUpdate(), msg);
+                s = LXMSupport.M64 * s + a;
+            }
+            Assertions.assertEquals(s, lcg.state(), msg);
+
+            final SubGen lcg2 = lcg.copyAndLongJump();
+            for (int j = 1 << LONG_JUMP; j-- != 0;) {
+                Assertions.assertEquals(s, lcg2.stateAndUpdate(), msg);
+                s = LXMSupport.M64 * s + a;
+            }
+            Assertions.assertEquals(s, lcg.state(), msg);
+        }
+
+        @RepeatedTest(value = 10)
+        void testLCG128() {
+            final SplittableRandom rng = new SplittableRandom();
+            final long stateh = rng.nextLong();
+            final long statel = rng.nextLong();
+            final long addh = rng.nextLong();
+            final long addl = rng.nextLong();
+            BigInteger s = toUnsignedBigInteger(stateh).shiftLeft(64).add(toUnsignedBigInteger(statel));
+            final BigInteger a = toUnsignedBigInteger(addh).shiftLeft(64).add(toUnsignedBigInteger(addl | 1));
+            final SubGen lcg = new LCG128(stateh, statel, addh, addl, NO_JUMP, NO_JUMP);
+            for (int j = 0; j < 10; j++) {
+                Assertions.assertEquals(s.shiftRight(64).longValue(), lcg.stateAndUpdate(),
+                        () -> String.format("seed %d,%d,%d,%d", stateh, statel, addh, addl));
+                s = M.multiply(s).add(a).mod(MOD);
+            }
+        }
+
+        @RepeatedTest(value = 10)
+        void testLCG128Jump() {
+            final SplittableRandom rng = new SplittableRandom();
+            final long stateh = rng.nextLong();
+            final long statel = rng.nextLong();
+            final long addh = rng.nextLong();
+            final long addl = rng.nextLong();
+            final Supplier<String> msg = () -> String.format("seed %d,%d,%d,%d", stateh, statel, addh, addl);
+            BigInteger s = toUnsignedBigInteger(stateh).shiftLeft(64).add(toUnsignedBigInteger(statel));
+            final BigInteger a = toUnsignedBigInteger(addh).shiftLeft(64).add(toUnsignedBigInteger(addl | 1));
+            final SubGen lcg = new LCG128(stateh, statel, addh, addl, JUMP, LONG_JUMP);
+
+            final SubGen lcg1 = lcg.copyAndJump();
+            for (int j = 1 << JUMP; j-- != 0;) {
+                Assertions.assertEquals(s.shiftRight(64).longValue(), lcg1.stateAndUpdate(), msg);
+                s = M.multiply(s).add(a).mod(MOD);
+            }
+            Assertions.assertEquals(s.shiftRight(64).longValue(), lcg.state(), msg);
+
+            final SubGen lcg2 = lcg.copyAndLongJump();
+            for (int j = 1 << LONG_JUMP; j-- != 0;) {
+                Assertions.assertEquals(s.shiftRight(64).longValue(), lcg2.stateAndUpdate(), msg);
+                s = M.multiply(s).add(a).mod(MOD);
+            }
+            Assertions.assertEquals(s.shiftRight(64).longValue(), lcg.state(), msg);
+        }
+
+        /**
+         * Create a big integer treating the value as unsigned.
+         *
+         * @param v Value
+         * @return the big integer
+         */
+        private static BigInteger toUnsignedBigInteger(long v) {
+            return v < 0 ?
+                TWO_POW_63.add(BigInteger.valueOf(v & Long.MAX_VALUE)) :
+                BigInteger.valueOf(v);
+        }
+    }
+
+    /**
+     * Test the XBG implementations. These tests should execute only once, and not
+     * for each instance of the abstract outer class (i.e. the test is not {@code @Nested}).
+     *
+     * <p>Note: The XBG implementation are extensions of RNGs already verified against
+     * reference implementations. These tests ensure that the upper bits of the state is
+     * identical after {@code n} cycles then a jump; or a jump then {@code n} cycles.
+     * This is the functionality required for a jumpable XBG generator.
+     */
+    static class XBGTest {
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo128NoJump() {
+            final SplittableRandom r = new SplittableRandom();
+            assertNoJump(new XBGXoRoShiRo128(r.nextLong(), r.nextLong(), false));
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoShiRo256NoJump() {
+            final SplittableRandom r = new SplittableRandom();
+            assertNoJump(new XBGXoShiRo256(r.nextLong(), r.nextLong(), r.nextLong(), r.nextLong(), false));
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo1024NoJump() {
+            final SplittableRandom r = new SplittableRandom();
+            assertNoJump(new XBGXoRoShiRo1024(r.longs(16).toArray(), false));
+        }
+
+        void assertNoJump(SubGen g) {
+            final SubGen g1 = g.copyAndJump();
+            Assertions.assertNotSame(g, g1);
+            for (int i = 0; i < 10; i++) {
+                Assertions.assertEquals(g.stateAndUpdate(), g1.stateAndUpdate());
+            }
+            final SubGen g2 = g.copyAndLongJump();
+            Assertions.assertNotSame(g, g2);
+            for (int i = 0; i < 10; i++) {
+                Assertions.assertEquals(g.stateAndUpdate(), g2.stateAndUpdate());
+            }
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo128Jump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 2, XBGXoRoShiRo128::new, SubGen::copyAndJump);
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo128LongJump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 2, XBGXoRoShiRo128::new, SubGen::copyAndLongJump);
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoShiRo256Jump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 4, XBGXoShiRo256::new, SubGen::copyAndJump);
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXShiRo256LongJump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 4, XBGXoShiRo256::new, SubGen::copyAndLongJump);
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo1024Jump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 16, XBGXoRoShiRo1024::new, SubGen::copyAndJump);
+        }
+
+        @RepeatedTest(value = 5)
+        void testXBGXoRoShiRo1024LongJump() {
+            assertJumpAndCycle(ThreadLocalRandom.current().nextLong(), 16, XBGXoRoShiRo1024::new, SubGen::copyAndLongJump);
+        }
+
+        /**
+         * Assert alternating jump and cycle of the XBG.
+         *
+         * <p>This test verifies one generator can jump and advance {@code n} steps
+         * while the other generator advances {@code n} steps then jumps. The two should
+         * be in the same state. The copy left behind by the first jump should match the
+         * state of the other generator as it cycles.
+         *
+         * @param testSeed A seed for the test
+         * @param seedSize The seed size
+         * @param factory Factory to create the XBG
+         * @param jump XBG jump function
+         */
+        private static void assertJumpAndCycle(long testSeed, int seedSize,
+                Function<long[], SubGen> factory, UnaryOperator<SubGen> jump) {
+            final SplittableRandom r = new SplittableRandom(testSeed);
+            final long[] seed = r.longs(seedSize).toArray();
+            final int[] steps = createSteps(r, seedSize);
+            final int cycles = 2 * seedSize;
+
+            final SubGen rng1 = factory.apply(seed);
+            final SubGen rng2 = factory.apply(seed);
+
+            // Try jumping and stepping with a number of steps up to the seed size
+            for (int i = 0; i < steps.length; i++) {
+                final int step = steps[i];
+                final int index = i;
+                // Jump 1
+                final SubGen copy = jump.apply(rng1);
+                // Advance 2; it should match the copy
+                for (int j = 0; j < step; j++) {
+                    Assertions.assertEquals(rng2.stateAndUpdate(), copy.stateAndUpdate(),
+                        () -> String.format("[%d] Incorrect trailing copy, seed=%d", index, testSeed));
+                    // Advance in parallel
+                    rng1.update();
+                }
+                // Catch up 2; it should match 1
+                jump.apply(rng2);
+                for (int j = 0; j < cycles; j++) {
+                    Assertions.assertEquals(rng1.stateAndUpdate(), rng2.stateAndUpdate(),
+                        () -> String.format("[%d] Incorrect after catch up jump, seed=%d", index, testSeed));
+                }
+            }
+        }
+    }
+
+    /////////////////////////////////////
+    // Tests for the LXM implementation
+    /////////////////////////////////////
+
+    /**
+     * Gets the factory to create a composite LXM generator.
+     * The generator is used to provide reference output for the generator under test.
+     *
+     * @return the factory
+     */
+    abstract LXMGeneratorFactory getFactory();
+
+    /**
+     * Creates a new instance of the RNG under test.
+     *
+     * @param seed the seed
+     * @return the RNG
+     */
+    abstract LongJumpableUniformRandomProvider create(long[] seed);
+
+    /**
+     * Gets a stream of reference data. Each Argument consist of the long array seed and
+     * the long array of the expected output from the LXM generator.
+     * <pre>
+     * long[] seed;
+     * long[] expected;
+     * return Stream.of(Arguments.of(seed, expected));
+     * </pre>
+     *
+     * @return the reference data
+     */
+    abstract Stream<Arguments> getReferenceData();
+
+    /**
+     * Test the reference data with the LXM generator.
+     * The reference data should be created with a reference implementation of the
+     * LXM algorithm, for example the implementations in JDK 17.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    final void testReferenceData(long[] seed, long[] expected) {
+        RandomAssert.assertEquals(expected, create(seed));
+    }
+
+    /**
+     * Test the reference data with the composite LXM generator. This ensures the composite
+     * correctly implements the LXM algorithm.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    final void testReferenceDataWithComposite(long[] seed, long[] expected) {
+        RandomAssert.assertEquals(expected, getFactory().create(seed));
+    }
+
+    /**
+     * Test initial output is the mix of the most significant bits of the LCG and XBG state.
+     * This test ensures the LXM algorithm applies the mix function to the current state
+     * before state update. Thus the initial output should be a direct mix of the seed state.
+     */
+    @RepeatedTest(value = 5)
+    final void testInitialOutput() {
+        final long[] seed = createRandomSeed();
+        // Upper 64 bits of LCG state
+        final long s = seed[getFactory().xbgSeedSize()];
+        // Upper 64 bits of XBG state
+        final long t = seed[0];
+        Assertions.assertEquals(getFactory().getMix().apply(s, t), create(seed).nextLong());
+    }
+
+    @Test
+    final void testConstructorWithZeroSeedIsPartiallyFunctional() {
+        // Note: It is impractical to demonstrate the RNG is partially functional:
+        // output quality may be statistically poor and the period is that of the LCG.
+        // The test demonstrates the RNG is not totally non-functional with a zero seed
+        // which is not the case for a standard XBG.
+        final int seedSize = getFactory().seedSize();
+        RandomAssert.assertNextLongNonZeroOutput(create(new long[seedSize]), 0, seedSize);
+    }
+
+    @Test
+    final void testConstructorWithSingleBitXBGSeedIsFunctional() {
+        // Create a dummy instance to obtain the class at runtime for the test
+        final LongJumpableUniformRandomProvider rng = create(new long[getFactory().seedSize()]);
+        RandomAssert.assertLongArrayConstructorWithSingleBitSeedIsFunctional(
+             rng.getClass(), getFactory().xbgSeedSize());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    final void testConstructorWithoutFullLengthSeed(long[] seed) {
+        // Hit the case when the input seed is self-seeded when not full length
+        final int seedSize = getFactory().seedSize();
+        RandomAssert.assertNextLongNonZeroOutput(new L128X128Mix(new long[] {seed[0]}),
+                seedSize, seedSize);
+    }
+
+    @RepeatedTest(value = 5)
+    final void testConstructorIgnoresFinalSeedBit() {
+        final long[] seed1 = createRandomSeed();
+        final long[] seed2 = seed1.clone();
+        final int seedSize = getFactory().seedSize();
+        // seed1 unset final bit; seed2 set final bit
+        seed1[seedSize - 1] &= -1L << 1;
+        seed2[seedSize - 1] |= 1;
+        Assertions.assertEquals(1, seed1[seedSize - 1] ^ seed2[seedSize - 1]);
+        final LongJumpableUniformRandomProvider rng1 = create(seed1);
+        final LongJumpableUniformRandomProvider rng2 = create(seed2);
+        RandomAssert.assertNextLongEquals(seedSize * 2, rng1, rng2);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    final void testJump(long[] seed, long[] expected) {
+        final long[] expectedAfter = createExpectedSequence(seed, expected.length, false);
+        RandomAssert.assertJumpEquals(expected, expectedAfter, create(seed));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    final void testLongJump(long[] seed, long[] expected) {
+        final long[] expectedAfter = createExpectedSequence(seed, expected.length, true);
+        RandomAssert.assertLongJumpEquals(expected, expectedAfter, create(seed));
+    }
+
+    @RepeatedTest(value = 5)
+    final void testJumpAndOutput() {
+        assertJumpAndOutput(false, ThreadLocalRandom.current().nextLong());
+    }
+
+    @RepeatedTest(value = 5)
+    final void testLongJumpAndOutput() {
+        assertJumpAndOutput(true, ThreadLocalRandom.current().nextLong());
+    }
+
+    /**
+     * Assert alternating jump and output from the LXM generator and the
+     * reference composite LXM generator.
+     *
+     * <p>The composite generator uses an LCG that is tested to match
+     * output after a jump (see {@link LCGTest} or a series of cycles.
+     * The XBG generator is <em>assumed</em> to function similarly.
+     * The {@link XBGTest} verifies that the generator is in the same
+     * state when using {@code n} steps then a jump; or a jump then
+     * {@code n} steps.
+     *
+     * <p>This test verifies one LXM generator can jump and advance
+     * {@code n} steps while the other generator advances {@code n}
+     * steps then jumps. The two should be in the same state. The copy
+     * left behind by the first jump should match the output of the other
+     * generator as it cycles.
+     *
+     * @param longJump If true use the long jump; otherwise the jump
+     * @param testSeed A seed for the test
+     */
+    private void assertJumpAndOutput(boolean longJump, long testSeed) {
+        final SplittableRandom r = new SplittableRandom(testSeed);
+        final long[] seed = createRandomSeed(r::nextLong);
+        final int[] steps = createSteps(r);
+        final int cycles = getFactory().seedSize();
+
+        LongJumpableUniformRandomProvider rng1 = create(seed);
+        LongJumpableUniformRandomProvider rng2 = getFactory().create(seed);
+
+        final UnaryOperator<LongJumpableUniformRandomProvider> jump = longJump ?
+            x -> (LongJumpableUniformRandomProvider) x.longJump() :
+            x -> (LongJumpableUniformRandomProvider) x.jump();
+
+        // Alternate jumping and stepping then stepping and jumping.
+        for (int i = 0; i < steps.length; i++) {
+            final int step = steps[i];
+            final int index = i;
+            // Jump 1
+            LongJumpableUniformRandomProvider copy = jump.apply(rng1);
+            // Advance 2; it should match the copy
+            for (int j = 0; j < step; j++) {
+                Assertions.assertEquals(rng2.nextLong(), copy.nextLong(),
+                    () -> String.format("[%d] Incorrect trailing copy, seed=%d", index, testSeed));
+                // Advance 1 in parallel
+                rng1.nextLong();
+            }
+            // Catch up 2; it should match 1
+            jump.apply(rng2);
+            for (int j = 0; j < cycles; j++) {
+                Assertions.assertEquals(rng1.nextLong(), rng2.nextLong(),
+                    () -> String.format("[%d] Incorrect after catch up jump, seed=%d", index, testSeed));
+            }
+
+            // Swap
+            copy = rng1;
+            rng1 = rng2;
+            rng2 = copy;
+        }
+    }
+
+    @RepeatedTest(value = 5)
+    final void testSaveRestoreAfterJump() {
+        assertSaveRestoreAfterJump(false, ThreadLocalRandom.current().nextLong());
+    }
+
+    @RepeatedTest(value = 5)
+    final void testSaveRestoreAfterLongJump() {
+        assertSaveRestoreAfterJump(true, ThreadLocalRandom.current().nextLong());
+    }
+
+    /**
+     * Assert that the precomputation of the jump coefficients functions
+     * with saved/restore.
+     *
+     * @param longJump If true use the long jump; otherwise the jump
+     * @param testSeed A seed for the test
+     */
+    private void assertSaveRestoreAfterJump(boolean longJump, long testSeed) {
+        final SplittableRandom r = new SplittableRandom(testSeed);
+        final int cycles = getFactory().seedSize();
+
+        final UnaryOperator<LongJumpableUniformRandomProvider> jump = longJump ?
+            x -> (LongJumpableUniformRandomProvider) x.longJump() :
+            x -> (LongJumpableUniformRandomProvider) x.jump();
+
+        // Create 2 generators and jump them which will precompute jump coefficients
+        final LongJumpableUniformRandomProvider rng1 = create(createRandomSeed(r::nextLong));
+        final LongJumpableUniformRandomProvider rng2 = create(createRandomSeed(r::nextLong));
+        jump.apply(rng1);
+        jump.apply(rng2);
+
+        // Restore the state from one to the other
+        RestorableUniformRandomProvider g1 = (RestorableUniformRandomProvider) rng1;
+        RestorableUniformRandomProvider g2 = (RestorableUniformRandomProvider) rng2;
+        g2.restoreState(g1.saveState());
+
+        // They should have the same output
+        RandomAssert.assertNextLongEquals(cycles, rng1, rng2);
+
+        // They should have the same output after a jump as the
+        // jump coefficients should be re-computed (or restored from the state too)
+        jump.apply(rng1);
+        jump.apply(rng2);
+
+        RandomAssert.assertNextLongEquals(cycles, rng1, rng2);
+    }
+
+    /**
+     * Create the expected sequence after a jump by advancing the XBG and LCG
+     * sub-generators. This is done by creating and jumping the composite LXM
+     * generator.
+     *
+     * @param seed the seed
+     * @param length the length of the expected sequence
+     * @param longJump If true use the long jump; otherwise the jump
+     * @return the expected sequence
+     */
+    private long[] createExpectedSequence(long[] seed, int length, boolean longJump) {
+        final LXMGenerator rng = getFactory().create(seed);
+        if (longJump) {
+            rng.longJump();
+        } else {
+            rng.jump();
+        }
+        return LongStream.generate(rng::nextLong).limit(length).toArray();
+    }
+
+    /**
+     * Creates a random seed of the correct length. Used when the seed can be anything.
+     *
+     * @return the seed
+     */
+    private long[] createRandomSeed() {
+        return createRandomSeed(new SplittableRandom()::nextLong);
+    }
+
+    /**
+     * Creates a random seed of the correct length using the provided generator.
+     * Used when the seed can be anything.
+     *
+     * @param gen the generator
+     * @return the seed
+     */
+    private long[] createRandomSeed(LongSupplier gen) {
+        return LongStream.generate(gen).limit(getFactory().seedSize()).toArray();
+    }
+
+    /**
+     * Creates a random permutation of steps in [1, seed size].
+     * The seed size is obtained from the LXM generator factory.
+     *
+     * @param rng Source of randomness
+     * @return the steps
+     */
+    private int[] createSteps(SplittableRandom rng) {
+        return createSteps(rng, getFactory().seedSize());
+    }
+
+    /**
+     * Creates a random permutation of steps in [1, seed size].
+     *
+     * @param rng Source of randomness
+     * @param seedSize Seed size
+     * @return the steps
+     */
+    private static int[] createSteps(SplittableRandom rng, int seedSize) {
+        final int[] steps = IntStream.rangeClosed(1, seedSize).toArray();
+        // Fisher-Yates shuffle
+        for (int i = steps.length; i > 1; i--) {
+            final int j = rng.nextInt(i);
+            final int tmp = steps[i - 1];
+            steps[i - 1] = steps[j];
+            steps[j] = tmp;
+        }
+        return steps;
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X1024MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X1024MixTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L128X1024Mix}.
+ */
+class L128X1024MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 4;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 16;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG128(seed[16], seed[17], seed[18], seed[19]),
+                                    new XBGXoRoShiRo1024(seed, false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L128X1024Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L128X1024MixRandom").create(seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0xe9214a30656c6621L, 0xce317a274f194d16L, 0x0274414662435445L, 0x1475285b682c1901L,
+                    0x1c370d7a6759381aL, 0x752d7d727966663aL, 0x2e2d131f10190254L, 0x7f0f0f5032053132L,
+                    0x1f617a47474b144dL, 0x0539411a037e693dL, 0x373801350060224cL, 0x01393b2c1b122104L,
+                    0x7808676475605545L, 0xec3764576637392dL, 0x9c22290673241d03L, 0xcb4031176e673e07L,
+                    0x4d0623076241212cL, 0x1a771f1c4849561dL, 0x847907737f670a2cL, 0xcb60793f261c7702L,
+                },
+                new long[] {
+                    0x16a64b86bb4f77e8L, 0x08652ab51a725fe6L, 0x352b20ab3eb0e6e8L, 0xd3dfb9080cd0fff3L,
+                    0x679bb8834b8c39edL, 0x1db09e09b224efdbL, 0x15ad68e0b42df0ccL, 0xf0b3d174dee2f4d3L,
+                    0x10c2523ca4a4c906L, 0x07fb1f38ebb06949L, 0xe17296e0a4551815L, 0x4e767b11277bd5b7L,
+                    0xd2861b50ab58769eL, 0x9fda6327293b6edbL, 0xa700b1b39c091649L, 0x3fdb8ab4d3181817L,
+                    0xe8e650db502c46f1L, 0xfc6983d3b5499938L, 0x15ffd7b60dbbc81eL, 0xf21885310202f639L,
+                    0x416731e4a25fe54eL, 0xc96a09a45aafdbabL, 0xceebcd6c3eb7f410L, 0x6965dd7f2e5be202L,
+                    0xb135778200cebda5L, 0x323946de66ea8efcL, 0xd99f8550d934b1a7L, 0x7d54c10751e1943fL,
+                    0xfa58243c8f26168aL, 0x4f9503a63b956ac1L, 0xd717de76262d1689L, 0x2dae4df5fd85d281L,
+                    0xab587b41f01c52abL, 0x3a0ec6c60fbf40f2L, 0x85b92bcf3709aa15L, 0x81c19f123efa68fbL,
+                    0xac06a72f4dbc17edL, 0xd98df600b51e4f48L, 0x009871f979161bf1L, 0xb63b478960527bd5L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xab0b405e243f6655L, 0x7220783e26481705L, 0x3f1a2f071f22787dL, 0x2d624a5a5a1a487cL,
+                    0x643935551a0e1744L, 0x5a663f673a506b3aL, 0x76186d1e7a081e14L, 0xf64a453f6f2d5d4dL,
+                    0xec27754b5a230725L, 0x852e03364b2d2535L, 0xb71f004f51605102L, 0x0a0c7d68300d575bL,
+                    0x9943777910780256L, 0x383b43005c1c4a77L, 0x9923163f2e246e2eL, 0x2e7a657e1079281bL,
+                    0x726865045a421d0aL, 0x905a1c0f777c280fL, 0x3d4306735a152d71L, 0xc1503e7e2f76750bL,
+                },
+                new long[] {
+                    0x43843e06d6aa8933L, 0x760b374cdcc21a2eL, 0xf02694e16403b8d2L, 0x3c14fd3a09551e59L,
+                    0xcd9acc1bf34253d8L, 0xa2677f96de7f389fL, 0xedaec653655a85f2L, 0x30e1bc7dd9e931fdL,
+                    0x9ee8ae96e94e61beL, 0x6949cf0a241bbd7bL, 0x72ed6630513dfed0L, 0x9bd0ebfc89db4d8dL,
+                    0xdd6f0a8f70451e3dL, 0x59e9fb17058f1fe2L, 0xd29197fffc0ce21dL, 0x424d6b309b44d7deL,
+                    0x8ce459db11a1abbfL, 0xf7f56ebd0a9f8578L, 0xe54de673fd1a7d54L, 0x11bd4054dd8f2ea0L,
+                    0xb15c3202a4eecb51L, 0xc93e7c2a0c44487bL, 0xf505494bc0e60deaL, 0xdb73777f97262200L,
+                    0xada728f47bff2975L, 0x501d543141ac9285L, 0xe14f70683e9442a1L, 0x6d44ceeccf039483L,
+                    0x4bf0401aeca9de03L, 0xba0bd837fb8850a7L, 0xf3ef477cee53d8a1L, 0x84866359a6dcdbceL,
+                    0xf38284481dfa4ab6L, 0x9b1c6c1bf3ceee63L, 0x4254e6ac337f55fbL, 0x3f5b499c46a13ddfL,
+                    0xf6d4ea2708c600caL, 0x4c7a9c3c986f4a7aL, 0x4a7aa1e3fe17b370L, 0x03e457ba810546f8L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x15462b005234675cL, 0x100c3674063b4d2bL, 0xc67f0c760c2a4149L, 0x36530758667a4017L,
+                    0x0f527d1a20512f38L, 0x224d0430615c4009L, 0x857d5f576c20290eL, 0x247d23184508793fL,
+                    0xed530606415c5d7aL, 0x194e7a0103414b12L, 0x2e03337c393e080bL, 0x736a171f506e5350L,
+                    0x0c59070650497402L, 0x287b01437241213fL, 0xf60e374d567a3f6cL, 0xa9635e395b2f5f03L,
+                    0x3a1e141f643a1a15L, 0x35584a2c3a514d6dL, 0x5a3436133e6d4878L, 0xbd471a486c233413L,
+                },
+                new long[] {
+                    0x6e4abb493293e3cfL, 0x57534af73dcd1d1eL, 0x0c66796854cb1e56L, 0xe3c3b560cf82b3baL,
+                    0xab53f3c3ca41c10dL, 0x278f0028e279a327L, 0xcca0f86cdb902d14L, 0x442046c504f378a2L,
+                    0xf799e6907cfff304L, 0xd5d703efa5e39620L, 0xd54f7043ee6c03d5L, 0xc7713f5af1ead63dL,
+                    0x857d603adc723d19L, 0x42a1147bc4844e0fL, 0x204993b253531d7cL, 0x67cc7cae796e3297L,
+                    0x7e17cc851367c8b3L, 0xae6d089adc64d157L, 0x54bf513c06041c2fL, 0x5975f68e8b1c3cbbL,
+                    0x30551255b5e791dcL, 0xb5500a471d2bf585L, 0x5eafdd741ed469beL, 0x34ddf80f26fbd921L,
+                    0x45704fee22f2c0a0L, 0x4735f0ec33fdf033L, 0x6864735d1bbe507eL, 0x47627355d302620cL,
+                    0xe99b2b58c414399cL, 0x7d8a28cba60e5938L, 0xc29fd6a62a43fdf6L, 0x4715e2b8c3637eedL,
+                    0xfdd17d771ccc525dL, 0xeb99d1815b304ef1L, 0x9679eb1d3b133e68L, 0xcabcd9a42c445c99L,
+                    0x479d66e6c85c98beL, 0xba9516550452d729L, 0x299e54b50cebe420L, 0x8fde3ca654cd399dL,
+                }));
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract transform() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testTransformThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L128X1024Mix(seed).transform(123, 456));
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X128MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X128MixTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L128X128Mix}.
+ */
+class L128X128MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 4;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG128(seed[2], seed[3], seed[4], seed[5]),
+                                    new XBGXoRoShiRo128(seed[0], seed[1], false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L128X128Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L128X128MixRandom").create(seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0xf60962173e0c5742L, 0x3e7f5f502633755fL, 0xba324e3c4d146537L, 0x16364205433a7113L,
+                    0x3a297b7429761628L, 0x9d21645f201b7021L,
+                },
+                new long[] {
+                    0x1ea7a5960faef34dL, 0xe77f9f6290dc93f2L, 0x74aefd78ce4030fdL, 0xc081b6e4c3595c02L,
+                    0x3b1edc17aa95bcb4L, 0xc14bf25e77010cb2L, 0xe7395dfccaa9dbcaL, 0xbebad53c986c6f58L,
+                    0x8f8a7583d30ec2e4L, 0xe2c541e3be5ea9b0L, 0x3bd9827396ed52fcL, 0xf21e25d719195bd6L,
+                    0x133fdd3ec02e5349L, 0xe4173fa34456f84cL, 0xf749b087f88e3cefL, 0xd078170802484e3cL,
+                    0x05f06c0da0b2fa8bL, 0x42b7c01bcf46c009L, 0xeae2728936c06176L, 0x71b6f995578a341dL,
+                    0x1dc20c1eb7dde50bL, 0x4dfe3a2dc06884f9L, 0x53f8a64ef6620772L, 0x09f05fe07be6c5aaL,
+                    0x019dd2cec64bd224L, 0xc91122977e5795a1L, 0x5ca628e227a9c59cL, 0x1c45e0b0ba328638L,
+                    0x431beb396ed3d853L, 0x270db91f7a43193cL, 0xba22d45ffa952da8L, 0xa03026f48d0a16eaL,
+                    0xd59e56fa28a9fd0bL, 0x5d3e3178bf2d1bddL, 0xd4a01fc739524149L, 0x08d25b8c425dcbedL,
+                    0x6b53b7544bd12866L, 0x4c1ba8e9baacd1d4L, 0x6a2c03ce0e64be9eL, 0xaef1188c7b49e967L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x02442c63271c2e65L, 0xa8256d670f6a0f50L, 0x48712e101702612cL, 0x52564c1c0c462c6aL,
+                    0xab05120b1d68141aL, 0xaa16702f314b0958L,
+                },
+                new long[] {
+                    0xb26e759a441f5966L, 0xc754e012f0e5b695L, 0x6f63edc0e02b9339L, 0xe3b4a2f074e68065L,
+                    0x50e3133fee680fb1L, 0x4806d74486f1047aL, 0x636a4bb9b1588135L, 0xa38a1d12165a1a5eL,
+                    0x1c93a08893b5d460L, 0xe5f12c095908d68bL, 0xc8209614bdf5c3aaL, 0x269514b48092e05cL,
+                    0xf53376fb46c4068fL, 0x1c29c163c83808a1L, 0x4e061b72e2558d90L, 0x764dbe734460cd58L,
+                    0x951eed50f2688936L, 0x90c431c196e7caa2L, 0x546c18e2ae8449cbL, 0xfa53c4db8f104337L,
+                    0x6101109a7906c635L, 0xd60391b908c7689aL, 0x2edba3f7777b0fceL, 0xc58ec62f686cfafeL,
+                    0xb46e6b9a63f7a5c8L, 0x0882126f0efd1c8cL, 0xb0a74862abb8fdceL, 0xeb73ae25e8d0cb13L,
+                    0x6d2cabda24960b3fL, 0xa066055ef4918eb3L, 0x5e41aee4befadce1L, 0x8d0188693ebc3e89L,
+                    0x42b7171e98c7ba4bL, 0x6cf4919164a36dedL, 0xd90883fa3b33a4daL, 0x01ac3a18f4020a05L,
+                    0x1ec9164000c2c5c3L, 0xa90a377959d611baL, 0x4719833abe706dc0L, 0xf9a18b8597be90c8L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x50253d7d19161d66L, 0x5f64221100172276L, 0xaa502d6b5e676c61L, 0xe94d1d266d030b23L,
+                    0x68034679056f6362L, 0xe666227323110c1cL,
+                },
+                new long[] {
+                    0xcf85d748550aaf08L, 0xa1903ba42f5c24a0L, 0x64df004d9a06460aL, 0xfbf4062ca343346cL,
+                    0x5bdf77cdfdac6cf8L, 0x5e16cbd71a4020a3L, 0x3835ab4dde607646L, 0xa1ccb3ec0909470cL,
+                    0x3d6f31f8aedb785fL, 0x8214004c996c8bf6L, 0xc6c775f354564e3cL, 0x6054e091e54a7278L,
+                    0xd7a4b3827266b0fdL, 0x78ef85c8c29cc270L, 0x1e92d5e38336284bL, 0xd2d7939efd300d8aL,
+                    0xa3b4a28536af8e04L, 0x5f1510ef2c9611dbL, 0xacbffd845e921744L, 0xeb46cad5d2c25cd9L,
+                    0xd449bc48ce4c0288L, 0x738064dc34ed21a9L, 0xac85af76c0d4ae3eL, 0xf04885858cce92f8L,
+                    0x3288572bff8677d4L, 0xc58371958117ecd1L, 0x018a1d0d5f6d6bb7L, 0xe29afe1c6f54208fL,
+                    0x724c19235787dfb1L, 0x1d47fde2388156eaL, 0xb6316593e1cc5ac8L, 0x15f8c8c913938180L,
+                    0x0d38390376df87feL, 0x950b50b0b4af2525L, 0x1d2d86b7b52aeabbL, 0x8331694e910a3705L,
+                    0xc962bf20dc7ae05bL, 0x07b911ecb2b6e5f8L, 0x2e814094668c24eaL, 0xc259ec3c9a99750aL,
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testElementConstructor(long[] seed, long[] expected) {
+        final L128X128Mix rng1 = new L128X128Mix(seed);
+        final L128X128Mix rng2 = new L128X128Mix(seed[0], seed[1], seed[2], seed[3], seed[4], seed[5]);
+        RandomAssert.assertNextLongEquals(seed.length * 2, rng1, rng2);
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract nextOutput() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testNextOutputThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L128X128Mix(seed).nextOutput());
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X256MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L128X256MixTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L128X256Mix}.
+ */
+class L128X256MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 4;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 4;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG128(seed[4], seed[5], seed[6], seed[7]),
+                                    new XBGXoShiRo256(seed[0], seed[1], seed[2], seed[3], false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L128X256Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L128X256MixRandom").create(seed)
+         * Full seed expanded from a single long value using the same method in the
+         * OpenJDK source (v17) and recorded in the order used by the Commons RNG code.
+         *
+         * Note: This is a different from the other LXMTest instances due to a constructor
+         * bug in JDK 17 L128X256MixRandom. The result is an initial state for the LCG
+         * that is always 1L.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0xa56f550e4455ad6bL, 0xfa8c6a4c0b4f87c1L, 0x97aa5a6091689f0cL, 0x97774f9a7b01252aL,
+                    0x0000000000000000L, 0x0000000000000001L, 0xaac2f67d761dadc6L, 0xe584ab0136fa95fcL,
+                },
+                new long[] {
+                    0x0f6839e2df51d066L, 0x63828bfa952b7223L, 0x1449a6518fc6698aL, 0xf0d255739e8a95a9L,
+                    0xdc2277916582ab84L, 0x855172869dc4ad71L, 0x9f1e38cd53f3aeceL, 0x8f0cfee1ed210171L,
+                    0xdb86b178e98ef8d0L, 0x6e53a3629d1485f7L, 0x033da8ec17c6256cL, 0x94a44e70d72cd494L,
+                    0x71a2171e09f1503dL, 0x6355ff323a49300eL, 0x4d4f7e37beec3a76L, 0x5391b119c23afe81L,
+                    0x21a28a3f83d71acaL, 0xe157ce29ed8a468dL, 0xfbcbeab9dfa54c0aL, 0x5bd0072c9751b499L,
+                    0x1f3ea8c1456a2cd3L, 0x656f6535b5a3d4d4L, 0xba7d0ee7b7cf61b8L, 0x8c26ad19a4660e2aL,
+                    0x9ca6f47a205fdcdeL, 0xa2ae34ee95f8d89eL, 0xb6de34b282c7b220L, 0xf8c1d88a8d284430L,
+                    0x4df71c7f08c3ad4bL, 0x9c7a7168f01b7905L, 0x93252635246315e0L, 0xcaaa648c929f8b87L,
+                    0x9d5f169be9b8050dL, 0xa24bb43e098948daL, 0x47d1147f27e102eeL, 0xcf80915231874ea4L,
+                    0xfb5a2832f261afc7L, 0xe4ed459ebe0e8d4dL, 0xa5f9df78cfed42d3L, 0x1cc368014904ab73L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x0114edb0b4bbfa18L, 0x83154f7914d38972L, 0x8d932b636513ae0eL, 0xa0bb24e85d97c9fcL,
+                    0x0000000000000000L, 0x0000000000000001L, 0x6e1a741ae7ec03ebL, 0xf5363e7b44211d57L,
+                },
+                new long[] {
+                    0x360b1762f284ac1aL, 0xc7e08eb6c5264259L, 0x60eabd90a111f141L, 0xbd3d95bdc05e96fdL,
+                    0xc12366f63a5cb505L, 0x30141aab158cf2deL, 0xefb1f62f804c4c02L, 0x198e4d8fdceed3f7L,
+                    0x178f01697a119a29L, 0x5ab2081161a38a08L, 0x0e02978d9d84e577L, 0x17286dbb65ec4b83L,
+                    0x15e5ccb7a1f5085aL, 0x11fdb06b66597f8cL, 0x4b8057b570a377c3L, 0xb274608cf0c9ec10L,
+                    0x9f220c4df7966a96L, 0x15bc1babf827161dL, 0x7ed132f78f8be153L, 0x38522a2d55b16e76L,
+                    0x70f56b472b9a589cL, 0x0c16b3de606a20b3L, 0x1e691d63b1e01619L, 0xe43b1de605c2efd8L,
+                    0x6fd7144c0a6b2f7eL, 0x9d2c424422c1e228L, 0xc3fdd9daf170c845L, 0xb5416500b7597222L,
+                    0x9d5beb65e35c57a4L, 0x3610afc9f107b341L, 0x26487e11ebcf8709L, 0x7e3f0ea4bbbe0d7bL,
+                    0xfeaa2d257997c2edL, 0xcf8974fcac8abcfaL, 0x1ae3d7733f7d9cffL, 0xdeb446665fe7c07eL,
+                    0x58a66ab0134febd5L, 0xcda459bb0c024431L, 0x109e6cfa2953268cL, 0xa74609ee30817c67L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xb610c4732da06560L, 0x60dfa764b8ae927dL, 0x24867e0eecc8eb78L, 0x952f3d5dc17c0cf2L,
+                    0x0000000000000000L, 0x0000000000000001L, 0x75576ea649c68bdfL, 0x988200da91af3658L,
+                },
+                new long[] {
+                    0x7c2bf5f25669c985L, 0x65f5ce67c1250090L, 0x131fb13c3f2b0af0L, 0xab6f976bc3783faeL,
+                    0xbac9b9bac68c1bb2L, 0x969a2438afc9eb6cL, 0x7e652efa93fc93b9L, 0xf1c6ccbd1333ea5bL,
+                    0x2a25a2c25ad454e8L, 0x002ed102a1146657L, 0x8f482f8aed7b4b41L, 0x1cc0b65ed2ce02c1L,
+                    0xad2c3f04da92abb0L, 0x3783c7d4f5bff2d8L, 0x8f1ddf96128c3d3eL, 0x8e10ceca6da015eeL,
+                    0x6bc2a9963a300b32L, 0xe7283e10d87a55eeL, 0x7737c78b6497ed8dL, 0x509181e37cbf2e52L,
+                    0x135e66e65ec985baL, 0xb191dd61abb669c7L, 0x82551e94692b0058L, 0x6acab0125b911923L,
+                    0x7ad6ebb617bfd61eL, 0xa2854d9a0b1fb89cL, 0xb5088284b426fe15L, 0x74621d1fc29f0ad7L,
+                    0xea5cf8ac302b12deL, 0xa8222d387b40a5a7L, 0x2dd23fd77aab83e0L, 0xd88147e1c98e69beL,
+                    0x7aaba7d84838fd21L, 0x933440a3dd8ecf5aL, 0xc6fe6e8cdb7d09e7L, 0xa00cab23b7a20207L,
+                    0xb769003d4abbef6bL, 0x119e829d8cdb859eL, 0x4cd41960d97c80a6L, 0xfb65ffaaf81144d3L,
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testElementConstructor(long[] seed, long[] expected) {
+        final L128X256Mix rng1 = new L128X256Mix(seed);
+        final L128X256Mix rng2 = new L128X256Mix(seed[0], seed[1], seed[2], seed[3],
+                                                 seed[4], seed[5], seed[6], seed[7]);
+        RandomAssert.assertNextLongEquals(seed.length * 2, rng1, rng2);
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract nextOutput() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testNextOutputThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L128X256Mix(seed).nextOutput());
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X1024MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X1024MixTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L64X1024Mix}.
+ */
+class L64X1024MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 16;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG64(seed[16], seed[17]),
+                                    new XBGXoRoShiRo1024(seed, false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L64X1024Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L64X1024MixRandom").create(seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0xd926667a2d47376fL, 0x4d6c207f3970190cL, 0x47674b1d727a1864L, 0xe9690738771f7564L,
+                    0x7b5772414c1d4911L, 0x4f1b6709796d554dL, 0x6830481709626056L, 0x0079145654746432L,
+                    0xd80557672c7b0f16L, 0x6c006c063728501aL, 0x224d1c2231223135L, 0xe54b38267c774412L,
+                    0x5e434374462a697cL, 0x5e523f08696d4154L, 0xec6e770542517a7aL, 0xc80f7b222063171fL,
+                    0x9a4072143201313bL, 0xca03226f3b01261dL,
+                },
+                new long[] {
+                    0x9e4cec0bbde71682L, 0x0c5743461d7efdb6L, 0xf53dd523366d85a4L, 0x71e8c10d41c40334L,
+                    0x3f220a99cfeada3aL, 0xfaf2e47b4b07ed4eL, 0x14ed83a98896ba31L, 0x9edebf98b36b1b9fL,
+                    0x0a9ba0f7b3ab6175L, 0x978afd6e4072b35fL, 0x692ad061d1a892c2L, 0x33ca5f76cab2d07cL,
+                    0x92c276ba933acc76L, 0xccba20e15efb8c73L, 0xd18002eecfb7f704L, 0x73c69198abd748a5L,
+                    0xcf97c9abcba58ce5L, 0x190c808fd9122ec2L, 0x51723fbb1e14b8f7L, 0x42e6ce0bc68aecd8L,
+                    0x3ac053dbfd27dc96L, 0x095303a8d8c740b3L, 0xeb6838e053ce700bL, 0x35c5c9d6bda511e2L,
+                    0xdc00af14c0ea9505L, 0x260353d68b8b6bf2L, 0xb8303edce2102ac0L, 0xc579aa4cd2c3bfe3L,
+                    0x36ba5233d4209182L, 0x11dfc73f40dd439dL, 0x697816afda914386L, 0x70a24741fb461579L,
+                    0x461c7f4f4e3e13aeL, 0xe451b43cc3faec68L, 0xdc1d659897a21cffL, 0xebe38fd616677617L,
+                    0x62572f9da023db27L, 0x227a328aaa96b26fL, 0x26b55d72e7cb3f28L, 0x820f8a339d14eb0aL,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x39446556365d1b21L, 0xb33d473545745f3aL, 0x276f081368096368L, 0x3518237203624325L,
+                    0xcd5308535c656b50L, 0x4d49137b5c026935L, 0xba536d2941171771L, 0x3364082c1712430bL,
+                    0xbc3e613e47150259L, 0xa75441394924054cL, 0xed2b66352a560b1fL, 0xd022471f3504144aL,
+                    0x2b604f50263a156cL, 0x1f12170a76035534L, 0xce294a2c74753b19L, 0x5e3f685b0b245661L,
+                    0xdb741039765b1e3aL, 0x5b464417077b2524L,
+                },
+                new long[] {
+                    0x00354c35c9ce8debL, 0x160325bf7614c724L, 0x31ab2503f939a58dL, 0x2b6d719d0d0b5ea3L,
+                    0xeaaa842ca62dc0b3L, 0x20eb6b2b74baedbeL, 0x9efeb411f9c6e328L, 0xa22ae76c0cfcf624L,
+                    0x4b66f8525cb6faecL, 0xc880b839d82ef494L, 0xfec62366978e29abL, 0x44a492a7b145becbL,
+                    0x1801a2bf4c9f47efL, 0x8489c117b90c73d3L, 0xa7dd633e622e3437L, 0x84941696c38d9d23L,
+                    0xa98faa3e6aaacdcfL, 0x19d59224a50095d0L, 0xe9c7239cd575c1c5L, 0xebdc11c43dbfef89L,
+                    0xe9873bce2133d419L, 0x1ee76f7efa7e7e64L, 0x7ad7abe737d78323L, 0xb636edf4f1690b89L,
+                    0xb03b4051ae7773a1L, 0x0115d01af9a3bdc6L, 0x8a0a958882934ec1L, 0x4d1f35f737ac69fdL,
+                    0xc232a55d6a13c97cL, 0x5238ad0760bfe5bcL, 0xeabdf873c076270bL, 0x517ac4dd13562203L,
+                    0x67f7c356484ba8b3L, 0x3bbef4723003e48bL, 0xf139f49d7f7a8dd8L, 0xdf75073a5f0387a8L,
+                    0x2288c8ad617b8076L, 0x36fe63b9fb97c59dL, 0xe1570ec1967a5186L, 0x6b945ae90b4d7f40L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xb85e5b5412716228L, 0xb041795a1e13265aL, 0x23310f54405f0721L, 0xc006072e53321602L,
+                    0xe00b775c5a122b02L, 0x465652350f4a6a07L, 0xad132729177f7718L, 0xd96122397040196fL,
+                    0x5a7602557020575fL, 0xd70904063e100a7fL, 0x51172f7872206f0dL, 0xa939510a4259666eL,
+                    0xbd300b4e75437a55L, 0x390b776402611b6bL, 0x653137325e691747L, 0x8067514f2a4d4d7bL,
+                    0xbc755d3c47642146L, 0xb12c333a355c7c1eL,
+                },
+                new long[] {
+                    0x54c1ce77f29f4f0eL, 0x01e8dccd6c287771L, 0xdca04ce508edb108L, 0x43eaaafc30d568c7L,
+                    0x6c127d5ac0c817a0L, 0x4a087f20c482a0b9L, 0x6e0f52f0f6661d53L, 0x2325216bedf5df1dL,
+                    0xaec61a8e97399dc8L, 0xb3915e80a05167c6L, 0x7da9dd81fc46eeb2L, 0x50ae26a8ec38edd0L,
+                    0x8a972cdcb0998498L, 0x3bf00b045c323ddaL, 0x9be071a64da0bf2dL, 0xf522fe5cafeb8a68L,
+                    0xacab485bf32ebfe6L, 0x16376a49fb6f0183L, 0xa3ae978f843cc96fL, 0xadf7ec319dae447eL,
+                    0x2fa3d25318594f29L, 0x9393b88f73fd1cb4L, 0x114c0987ff63717bL, 0xd682ac09b1c4ddc8L,
+                    0x483f5de1559da9a6L, 0xa94da376a7273489L, 0xd0c128feb97c394cL, 0x81291d7e85be4923L,
+                    0x250013089d41fc4eL, 0x3a20e0abfd4fc7f1L, 0x6f36b9287c1cc333L, 0x648fa8168da53117L,
+                    0xfc9ed78756025597L, 0x8f45c16fb8da57f5L, 0x2e03559e30bde857L, 0xd6e491f8c8c22546L,
+                    0xaa84a5cf5b0668caL, 0xecb643d0e758e7edL, 0xe6eba4065ff373abL, 0xb80a1412a869cef7L,
+                }));
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract transform() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testTransformThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L64X1024Mix(seed).transform(123, 456));
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X128MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X128MixTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L64X128Mix}.
+ */
+class L64X128MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG64(seed[2], seed[3]),
+                                    new XBGXoRoShiRo128(seed[0], seed[1], false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L64X128Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L64X128MixRandom").create(seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0x8827247f034c4e4dL, 0xea5508650a264226L, 0xc1231f1811655906L, 0x413b3d6c52481a65L,
+                },
+                new long[] {
+                    0xb4d113f36ccdd3fdL, 0xf26e7cb5c0390ec4L, 0x973ff8d2debe46b8L, 0x962e44b59daf2169L,
+                    0x8c7dd11775e9d55bL, 0x8763b0cafcca658fL, 0x4d748b8631a75017L, 0x17498c7364f32942L,
+                    0x2c1738406e82f6efL, 0x02214c1f300ab893L, 0xbbab56a4020b1be9L, 0x7a7b6ae910f98bcfL,
+                    0xa37204aa89e828bbL, 0x46580e4586e88e53L, 0x812332dd546fd80aL, 0x747e1c1ef176795fL,
+                    0xeb75d2315f29f405L, 0x39c6bad2a694c815L, 0xa00747ccd4d49a88L, 0x4c0b4679cebac0b0L,
+                    0x689523cbfb9e5b40L, 0xf4798ac6780a1823L, 0x447c43ed041a52beL, 0x5878850e65d9f209L,
+                    0xca89aa2b7b279b30L, 0xe7b98710421b974aL, 0x9cd4a033438fbc3aL, 0xe91dc3036b57e0f4L,
+                    0xbb3ccb76d805cf70L, 0xf1b608bc99b17c4eL, 0x48ce8348ba47ff4aL, 0x12bf180fc386fdd3L,
+                    0x06fcbf5e8ed7f11bL, 0x951df66a7ff90fffL, 0x25e4ba22b1d2c97dL, 0xa2450ee7e234acbeL,
+                    0x206794d092392fb4L, 0x751bc3f1ba29a78fL, 0xcacd6a825354a2a5L, 0x9f807a742ddf3c2eL,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xb156162d454f4406L, 0x2b1f603431544f14L, 0x1e140b1f2d047426L, 0x2c41500c4a40464fL,
+                },
+                new long[] {
+                    0x8ec1b80ecbdf6638L, 0x7d427e73692801feL, 0xa7d11c38e77bd3f9L, 0xb70a427f0f7b8242L,
+                    0x5b5aafca3afd3e77L, 0xb23cd1296d06029bL, 0x0eda6a18a61f04c7L, 0xa5dbdb8badbb0a19L,
+                    0xf482bcdd6bf246ecL, 0xdc3e5161265bd675L, 0x3dbf65ac75444016L, 0xaeabf78ddea24d43L,
+                    0x9a3e1aa6e98660ecL, 0x8719933d2a4f9d51L, 0x6a2c183328f2f108L, 0x8d6e6cb61bb7e254L,
+                    0x4123c3eb7a5a5e26L, 0x1c2d6e8ce8de78c4L, 0xf2f4d8ca8c529d88L, 0x6fed12ec6d63428fL,
+                    0x0c3404aa52cb98e0L, 0xebc4d88cedcd573cL, 0x6dacde15cde2938aL, 0x7faf0fc88902a4f4L,
+                    0x2cc7b1ed35a49de7L, 0xedfdb738b0b51f34L, 0xb7403fdcd5623f05L, 0x344dd5453feff140L,
+                    0x1cd944bd864e44ecL, 0xf3a728bb7bd944bbL, 0xac9e1c57f53166bfL, 0x77a1167656ff9afbL,
+                    0x3bf2621282d1fb4bL, 0x37730904ed22f5e3L, 0x357c76a47629e24dL, 0x0656773b6cac7efeL,
+                    0x1bcfa143e2649c7fL, 0x4907de5c28fcc710L, 0x8aff7d708155fdf9L, 0x697687aef87dd832L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xd826310863145d67L, 0x28545c212559142eL, 0xb86e7364396a5f5fL, 0x69472c09433c4245L,
+                },
+                new long[] {
+                    0xfa3f7883551b65c4L, 0x5537e7a29730dba9L, 0x171dfb4cdb51de33L, 0x55857dc286cee0b9L,
+                    0x232ae8dcad83fe7aL, 0x650afbab83268f46L, 0xc51c927f43e309d0L, 0x4b4bc38aedddeef9L,
+                    0x6c679933128f4adfL, 0x3a94141aeb654cbcL, 0xb9025dc647419e1eL, 0x0b6eeeecddf751aaL,
+                    0x3c0cb20257c3d1deL, 0x824ab0e63d512801L, 0xf4f11b8ff9792039L, 0xf0a712041f72b16dL,
+                    0x65232d0f0db89a31L, 0xde1dc59d9a3020deL, 0x012629ebd0e82e41L, 0x72bb791550469c08L,
+                    0x10acd0a730000863L, 0xf0dbdd652569feb1L, 0xb2a3505a6f8caadcL, 0x38b592bc58ffc6e2L,
+                    0xb79c9661f2a726f7L, 0x9fcc0d2b41cfd3ccL, 0x4bac2b22916e7805L, 0x19ddc2276290c8ffL,
+                    0x70a42053a130a2bbL, 0x915c2eec9a377a46L, 0x85b81aef329899f5L, 0xeddd96f8c61ae62dL,
+                    0xa8f7a4779614ca12L, 0x5ce66eb03e190499L, 0x845f24e22591c5e1L, 0xc26d1b8bd87d8009L,
+                    0xe894d1bb0e69824bL, 0x28c4c76880cec271L, 0xb887447c68200a4eL, 0xcb55ad59c43920cbL,
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testElementConstructor(long[] seed, long[] expected) {
+        final L64X128Mix rng1 = new L64X128Mix(seed);
+        final L64X128Mix rng2 = new L64X128Mix(seed[0], seed[1], seed[2], seed[3]);
+        RandomAssert.assertNextLongEquals(seed.length * 2, rng1, rng2);
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract nextOutput() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testNextOutputThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L64X128Mix(seed).nextOutput());
+    }
+
+    @Test
+    void test() {
+        for (int i = 1; i < 20; i += 2) {
+            new L64X128Mix(42, 43, 0, i).longJump();
+        }
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X128StarStarTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X128StarStarTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L64X128StarStar}.
+ */
+class L64X128StarStarTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG64(seed[2], seed[3]),
+                                    new XBGXoRoShiRo128(seed[0], seed[1], false));
+        }
+
+        @Override
+        public Mix getMix() {
+            return AbstractLXMTest::mixStarStar;
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L64X128StarStar(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L64X128StarStarRandom").create(
+         * seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0x90553f5a59676f25L, 0x590a4f291e16303fL, 0x02774b434710415eL, 0x9a6735334f764669L,
+                },
+                new long[] {
+                    0xfa2eda9a8503875eL, 0x40d2997cf3a8faa2L, 0xb782cb5e01cfbfe8L, 0x6f80294d7caccc20L,
+                    0x1415b29e01be890fL, 0xa7a184e3ae16d463L, 0xa27d0a5eac6f025cL, 0xa63c4bd5924f9c09L,
+                    0x91e045ca04392005L, 0x217117d21492258bL, 0xdcd5e74c08e9a8a6L, 0x9ae1eda89f8f8ce6L,
+                    0xb83d6fad06d9bccbL, 0xed96a0a8d3ba2232L, 0xd5a2730465123ec2L, 0x514212d2f65a3e68L,
+                    0x62439a2270b47780L, 0xa7a1a451402a983fL, 0xfaa331658e2610b2L, 0x5eb09511024e8962L,
+                    0xa98a44c94106f1d6L, 0x6350f0194244c038L, 0xc359b399832fd464L, 0x26a08f51b2caa80aL,
+                    0x4063c19cf92c8122L, 0x51a9e422a6cc8536L, 0x50412f9eb97447fdL, 0xd46551a24d3b3644L,
+                    0x9cb52774b1d76aeaL, 0x278a1794658b9809L, 0xe1e9901717b9935eL, 0xa7fc2b13259d8e1eL,
+                    0x9fe0ff858f44de81L, 0xd6f4f7217503f9b9L, 0xc341d1b3fe50029bL, 0x11b61829e61442d8L,
+                    0xabe181bddbc10dddL, 0xc1e84b3cda0c8cadL, 0x9f9ad08d6c2d04a2L, 0x1a69efc926ae734cL,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x3b31185c397d2e52L, 0xf01c3f7a25072270L, 0x3125364a71672453L, 0xac720a006d614309L,
+                },
+                new long[] {
+                    0x95e9a605114380feL, 0xc4ca92a0d8f35896L, 0x96a303974cf302d0L, 0xb82c651679cc2fecL,
+                    0x0f2d0498c8eb3d69L, 0x0184f46152b5b87bL, 0x3b78c3105abf46b2L, 0xe438cffc7df8d357L,
+                    0xc2be744f5e0b57baL, 0xc81dcaecd52aaa2fL, 0x6d7ef235a564cc20L, 0x7fb08ae36375ecf8L,
+                    0x81040c0645bf581bL, 0xdbb8f4c78ea8b15fL, 0x13a108fe1d370c74L, 0xc93b297927a6e4aaL,
+                    0x197a4fc2cc535c25L, 0x5e800e1bb478ca01L, 0x638d5ac226fbfb4fL, 0xfaee78320b426b13L,
+                    0xe13dc9e43f84df48L, 0x392847cd9f4b2233L, 0x48a6e2e4636389d6L, 0xe0e53e0b19cec7beL,
+                    0xb6459258787c8829L, 0x83b00e03ec5abffcL, 0xe517275e6afab602L, 0x4febfc2f98abd21fL,
+                    0x8bbe2ef1dff25e6cL, 0x2167cbac37bef5b8L, 0xfd047e45396ca725L, 0x170d226283dd4ef6L,
+                    0x39690beb723b8d07L, 0x306116b9d06d5509L, 0x3f49cf45882f0f67L, 0xdeca8c6a4b085bf5L,
+                    0x0e3b1e52ff7506bfL, 0xc2656d2d8fd459c2L, 0x0e4148af436156afL, 0x806e4553f786cd7dL,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x8874316d7b59490aL, 0xff31187b6059744cL, 0xda36353a6766765eL, 0xaf735c18397e6947L,
+                },
+                new long[] {
+                    0xfa05c16dda52a826L, 0xe9c523f07c5cb2b4L, 0x13ae41d65b14107dL, 0xf3e1173f543e509dL,
+                    0xc43eb0c67d3495c5L, 0x44edd79d203d8293L, 0xf2fccfe48084fc20L, 0x3c77d17b4850f6fdL,
+                    0x83f79eb77a62bb37L, 0x987c4f75be4133e9L, 0x0ee529d1f73a2099L, 0x7c9639d659ae4079L,
+                    0x2d191c7096a1ac90L, 0x9e4606d9dccd30d1L, 0x850c3dfc9386ecb1L, 0x77a00fb6cf9fb824L,
+                    0xdfe307b7c9faa672L, 0x3c4ee316952584ceL, 0x5feaf6e782fa5602L, 0x23d0b7c0aa85e8f3L,
+                    0x66d9f669dffceadcL, 0x4c00536a1a4fd75bL, 0x08e54b8bb6e6c5f9L, 0x3453c08c4b422660L,
+                    0x513269dd9e520177L, 0xd86591fb64fdd9dcL, 0xb7753a837e7cf44dL, 0xde8bdc2fd2c8d37fL,
+                    0x535f5931cb5acc8dL, 0x4e2d0d0823d2a562L, 0x99a9874c01c4b261L, 0x322dbf9da83b96f7L,
+                    0x468fe390218f10d8L, 0xc7c7b4405e830136L, 0x926beae7a25fe30cL, 0x648ad95805c12f29L,
+                    0x94ed61e84f718d12L, 0xf57931fcb440dd42L, 0x6759dde6dbe42de8L, 0xe48db87e5f0df1dbL,
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testElementConstructor(long[] seed, long[] expected) {
+        final L64X128StarStar rng1 = new L64X128StarStar(seed);
+        final L64X128StarStar rng2 = new L64X128StarStar(seed[0], seed[1], seed[2], seed[3]);
+        RandomAssert.assertNextLongEquals(seed.length * 2, rng1, rng2);
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract nextOutput() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testNextOutputThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L64X128StarStar(seed).nextOutput());
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X256MixTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/L64X256MixTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.util.stream.Stream;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.core.RandomAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link L64X256Mix}.
+ */
+class L64X256MixTest extends AbstractLXMTest {
+
+    /**
+     * Factory to create a composite LXM generator that is equivalent
+     * to the RNG under test.
+     */
+    private static class Factory implements LXMGeneratorFactory {
+        static final Factory INSTANCE = new Factory();
+
+        @Override
+        public int lcgSeedSize() {
+            return 2;
+        }
+
+        @Override
+        public int xbgSeedSize() {
+            return 4;
+        }
+
+        @Override
+        public LXMGenerator create(long[] seed) {
+            return new LXMGenerator(getMix(),
+                                    new LCG64(seed[4], seed[5]),
+                                    new XBGXoShiRo256(seed[0], seed[1], seed[2], seed[3], false));
+        }
+    }
+
+    @Override
+    LXMGeneratorFactory getFactory() {
+        return Factory.INSTANCE;
+    }
+
+    @Override
+    LongJumpableUniformRandomProvider create(long[] seed) {
+        return new L64X256Mix(seed);
+    }
+
+    @Override
+    Stream<Arguments> getReferenceData() {
+        /*
+         * Reference data from JDK 17:
+         * java.util.random.RandomGeneratorFactory.of("L64X256MixRandom").create(seed)
+         *
+         * Full byte[] seed created using SecureRandom.nextBytes. The seed was converted
+         * to long[] by filling the long bits sequentially starting at the most
+         * significant byte matching the method used by JDK 17. A sign extension bug in
+         * byte[] conversion required all byte indices (i % 8 != 0) to be non-negative.
+         * See: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8282144
+         *
+         * Note: Seed has been recorded in the order used by Commons RNG.
+         * JDK 17 seed order: LCG addition; LCG state; XBG state.
+         * Commons RNG seed order: XBG state; LCG state; LCG addition.
+         */
+        return Stream.of(
+            Arguments.of(
+                new long[] {
+                    0x5b241a23475c136bL, 0x611f57177c451714L, 0xe51a4670417c4929L, 0x83495b4512573b69L,
+                    0x6231564c7b67752eL, 0x2249232b631c5a33L,
+                },
+                new long[] {
+                    0x3b2581b0f7d47a44L, 0xae08c7439c0d9db8L, 0x667d577e8f0e7107L, 0xb127662052ba23dbL,
+                    0x283b9f648abff77dL, 0x8a79c3f4079291a7L, 0x0d569424123c789bL, 0x606769bee07389b4L,
+                    0x3ae004db1868e7d9L, 0x87cc2ca9fc7652acL, 0xc8f6be5980ad6a86L, 0x9bd9dcdbefb172beL,
+                    0x11e9c9fbca8109dcL, 0xd5e93ef6b9b2869fL, 0xafc5ad654ddadfeaL, 0xac02c6fd5734a004L,
+                    0x7bb48191736c2ee2L, 0xef3267674750942fL, 0x408d1e4a979ece93L, 0x28df1363bfbdc13cL,
+                    0x8e9018d64bb35ccaL, 0x1429a15115d3e447L, 0xa48b9d1f30d5c5dfL, 0x7341fddce66d825fL,
+                    0x1dcda0c69b88240fL, 0x5e3e88b0fa0cf62eL, 0xb31b0fd05fb0ceffL, 0x27f6cfa05d602b21L,
+                    0x2aa55a37ec2dd1a9L, 0xb9ecd3176de5aba0L, 0x0b60a5d210e80bfeL, 0xec3ae0690b5d36d0L,
+                    0xd36827e33c2610afL, 0x443701f20b0b55b9L, 0x9c44bc2e173606efL, 0x682bbfa8c8a76b12L,
+                    0xcbb50c8f008184d4L, 0x9a8f4dc4ace9dab7L, 0x635dbc0bba0acf56L, 0x2be7233ba0af3755L,
+                }),
+            Arguments.of(
+                new long[] {
+                    0x573d392b6d444672L, 0x391a0b7e7256257eL, 0xe3553c7338183a4bL, 0xb3453524327b474eL,
+                    0x1c48321c3f450a4bL, 0x5a6a3e055b336673L,
+                },
+                new long[] {
+                    0x497c9968fb30b55aL, 0x88b701c7c8a5ce87L, 0xc647de6f7c945818L, 0x15455e0da4e225cbL,
+                    0x05a8121c5ac13fb6L, 0xc7a2840d44d85358L, 0x035682005f927ac5L, 0x5c02d2bc69806329L,
+                    0x357b8b489e7dd1ceL, 0x31a3b0cb1e7ab647L, 0xc430e7726d89bfa5L, 0x7ff2b9985ce138b6L,
+                    0xc9d6a64623ceee4eL, 0x66d9f22310afd121L, 0x4947bd5dffa51e31L, 0x37643d00b4886c04L,
+                    0x87f629915e305f6fL, 0x219bcd75cbc0285aL, 0xe4c1297b5211a25aL, 0x40e1183164eac5ebL,
+                    0x09d9430c9b1b6987L, 0x992314f2bcda24f9L, 0x089ae6cd57c799c2L, 0xa00587bdd329cba0L,
+                    0xcb8b06012ff9b1daL, 0x42e9337d8d2cecd4L, 0x614bd447dff91cf6L, 0xa8544ea46a034e04L,
+                    0x92ff39c62c2d86efL, 0x2c1906c4b204a841L, 0xaa703346273b7e65L, 0x4c56a1e60ac062e2L,
+                    0x699d07dcece2f142L, 0xebec46c7fcf2854cL, 0xd474b44306a4ffa0L, 0xc2ec5ad575f8f2a1L,
+                    0x9465c39accfc4119L, 0x3848d247b91666baL, 0x746b4f3707e3d8b7L, 0x95a6a969a95f06bbL,
+                }),
+            Arguments.of(
+                new long[] {
+                    0xf2356277031d321eL, 0x84424261090c5f65L, 0x6971605d2e512524L, 0xda2440670153601fL,
+                    0x9a15215939207347L, 0x54400165483f2e3fL,
+                },
+                new long[] {
+                    0x8b1d7efc7fc06c1eL, 0x66d5acbd0eb82506L, 0x1ae1b0593b508681L, 0xb5257bc2cd864b10L,
+                    0x3b3ce25dba52b1ecL, 0xeba1c30537df5fb8L, 0x6de3e0b4727488f6L, 0x5cc1339198afa780L,
+                    0x53d7e6a0df40863dL, 0x29a12cf9852cd019L, 0x5a0063a3c5fb8edcL, 0x83877b4357d7bba9L,
+                    0x31927eacbf38d044L, 0x4b5b4edb1239316cL, 0xb2972e6b23a169d2L, 0x8a1b11d5aeb8e987L,
+                    0x9a43065171f7e6a3L, 0x0d1429e90174c8d3L, 0x569bbb67381c91faL, 0x54873f0e39ce40d6L,
+                    0x069ba230fdb29a2aL, 0xd3cbd59ae9ac652aL, 0xf82cbb27a9150de1L, 0x0013470c201fceaaL,
+                    0xf8d1b0b50662e153L, 0x57dcaa907fd596d4L, 0x400e840591ba1d54L, 0x5f7735e9f6904c01L,
+                    0x7a34f1dc7b3229a5L, 0x7aa5499d4f712524L, 0x0784bc58e37fec70L, 0x93770a8e29acb2d2L,
+                    0x9fcc1756e91b4c28L, 0xacfb91b7aac01d92L, 0x3ed26f0091a74012L, 0x3daffd2afe73d286L,
+                    0x4199ca7739b26126L, 0xd96d30747880bb7bL, 0x479432cba5b5f450L, 0x4b0aac6c79480b96L,
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testElementConstructor(long[] seed, long[] expected) {
+        final L64X256Mix rng1 = new L64X256Mix(seed);
+        final L64X256Mix rng2 = new L64X256Mix(seed[0], seed[1], seed[2], seed[3], seed[4], seed[5]);
+        RandomAssert.assertNextLongEquals(seed.length * 2, rng1, rng2);
+    }
+
+    /**
+     * This algorithm overrides next() directly to allow parallel pipelining of the
+     * output generation and the sub-generator update (a design feature of the LXM family).
+     * The abstract nextOutput() method should not be used. This test checks the method
+     * throws an exception if used.
+     */
+    @ParameterizedTest
+    @MethodSource(value = "getReferenceData")
+    void testNextOutputThrows(long[] seed) {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> new L64X256Mix(seed).nextOutput());
+    }
+}

--- a/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/LXMSupportTest.java
+++ b/commons-rng-core/src/test/java/org/apache/commons/rng/core/source64/LXMSupportTest.java
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.core.source64;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.SplittableRandom;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link LXMSupport}.
+ *
+ * <p>Note: The LXM generators require the LCG component to be advanced in a single
+ * jump operation by half the period 2<sup>k/2</sup>, where {@code k} is the LCG
+ * state size. This is performed in a single step using coefficients {@code m'} and
+ * {@code c'}.
+ *
+ * <p>This class contains a generic algorithm to compute an arbitrary
+ * LCG update for any power of 2. This can be bootstrap tested using small powers of
+ * 2 by manual LCG iteration. Small powers can then be used to verify increasingly
+ * large powers. The main {@link LXMSupport} class contains precomputed coefficients
+ * {@code m'} and a precursor to {@code c'} for a jump of 2<sup>k/2</sup>
+ * assuming the multiplier {@code m} used in the LXM generators. The coefficient
+ * {@code c'} is computed by multiplying by the generator additive constant. The output
+ * coefficients have the following properties:
+ * <ul>
+ * <li>The multiplier {@code m'} is constant.
+ * <li>The lower half of the multiplier {@code m'} is 1.
+ * <li>The lower half of the additive parameter {@code c'} is 0.
+ * <li>The upper half of the additive parameter {@code c'} is odd when {@code c} is odd.
+ * </ul>
+ */
+class LXMSupportTest {
+    /** 2^63. */
+    private static final BigInteger TWO_POW_63 = BigInteger.ONE.shiftLeft(63);
+    /** 2^128. The modulus of a 128-bit LCG. */
+    private static final BigInteger MOD = BigInteger.ONE.shiftLeft(128);
+    /** A mask to clear the lower 6 bits of an integer. */
+    private static final int CLEAR_LOWER_6 = -1 << 6;
+    /** A mask to clear the lower 7 bits of an integer. */
+    private static final int CLEAR_LOWER_7 = -1 << 7;
+
+    /**
+     * Test a seed can be expanded to a required size by filling with a SplitMix64 generator.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 4, 5, 6, 7, 8, 9})
+    void testEnsureSeedLength(int length) {
+        // The seed does not matter.
+        // Create random seeds that are smaller or larger than length.
+        final SplittableRandom rng = new SplittableRandom();
+        for (long[] seed : new long[][] {
+            {},
+            rng.longs(1).toArray(),
+            rng.longs(2).toArray(),
+            rng.longs(3).toArray(),
+            rng.longs(4).toArray(),
+            rng.longs(5).toArray(),
+            rng.longs(6).toArray(),
+            rng.longs(7).toArray(),
+            rng.longs(8).toArray(),
+            rng.longs(9).toArray(),
+        }) {
+            Assertions.assertArrayEquals(expandSeed(length, seed),
+                                         LXMSupport.ensureSeedLength(seed, length));
+        }
+    }
+
+    /**
+     * Expand the seed to the minimum specified length using a {@link SplitMix64} generator
+     * seeded with {@code seed[0]}, or zero if the seed length is zero.
+     *
+     * @param length the length
+     * @param seed the seed
+     * @return the seed
+     */
+    private static long[] expandSeed(int length, long... seed) {
+        if (seed.length < length) {
+            final long[] s = Arrays.copyOf(seed, length);
+            final SplitMix64 rng = new SplitMix64(s[0]);
+            for (int i = seed.length; i < length; i++) {
+                s[i] = rng.nextLong();
+            }
+            return s;
+        }
+        return seed;
+    }
+
+    @Test
+    void testLea64() {
+        // Code generated using the reference java code provided by Steele and Vigna:
+        // https://doi.org/10.1145/3485525
+        final long[] expected = {
+            0x45b8512f9ff46f10L, 0xd6ce3db0dd63efc3L, 0x47bf6058710f2a88L, 0x85b8c74e40981596L,
+            0xd77442e45944235eL, 0x3ea4255636bfb1c3L, 0x296ec3c9d3e0addcL, 0x6c285eb9694f6eb2L,
+            0x8121aeca2ba15b66L, 0x2b6d5c2848c4fdc4L, 0xcc99bc57f5e3e024L, 0xc00f59a3ad3666cbL,
+            0x74e5285467c20ae7L, 0xf4d51701e3ea9555L, 0x3aeb92e31a9b1a0eL, 0x5a1a0ce875c7dcaL,
+            0xb9a561fb7d82d0f3L, 0x97095f0ab633bf2fL, 0xfe74b5290c07c1d1L, 0x9dfd354727d45838L,
+            0xf6279a8801201eddL, 0x2db471b1d42860eeL, 0x4ee66ceb27bd34ecL, 0x2005875ad25bd11aL,
+            0x92eac4d1446a0204L, 0xa46087d5dd5fa38eL, 0x7967530c43faabe1L, 0xc53e1dd74fd9bd15L,
+            0x259001ab97cca8bcL, 0x5edf024ee6cb1d8bL, 0x3fc021bba7d0d7e6L, 0xf82cae56e00245dbL,
+            0xf1dc30974b524d02L, 0xe1f2f1db0af7ace9L, 0x853d5892ebccb9f6L, 0xe266f36a3121da55L,
+            0x3b034a81bad01622L, 0x852b53c14569ada2L, 0xee902ddc658c86c9L, 0xd9e926b766013254L,
+        };
+        long state = 0x012de1babb3c4104L;
+        final long increment = 0xc8161b4202294965L;
+
+        for (int i = 0; i < expected.length; i++) {
+            Assertions.assertEquals(expected[i], LXMSupport.lea64(state += increment));
+        }
+    }
+
+    @Test
+    void testUnsignedMultiplyHighEdgeCases() {
+        final long[] values = {
+            -1, 0, 1, Long.MAX_VALUE, Long.MIN_VALUE, LXMSupport.M128L,
+            0xffL, 0xff00L, 0xff0000L, 0xff000000L,
+            0xff00000000L, 0xff0000000000L, 0xff000000000000L, 0xff000000000000L,
+            0xffffL, 0xffff0000L, 0xffff00000000L, 0xffff000000000000L,
+            0xffffffffL, 0xffffffff00000000L
+        };
+
+        for (final long v1 : values) {
+            for (final long v2 : values) {
+                assertMultiply(v1, v2, LXMSupport.unsignedMultiplyHigh(v1, v2));
+            }
+        }
+    }
+
+    @Test
+    void testUnsignedMultiplyHigh() {
+        final long[] values = new SplittableRandom().longs(100).toArray();
+        for (final long v1 : values) {
+            for (final long v2 : values) {
+                assertMultiply(v1, v2, LXMSupport.unsignedMultiplyHigh(v1, v2));
+            }
+        }
+    }
+
+    private static void assertMultiply(long v1, long v2, long hi) {
+        final BigInteger bi1 = toUnsignedBigInteger(v1);
+        final BigInteger bi2 = toUnsignedBigInteger(v2);
+        final BigInteger expected = bi1.multiply(bi2);
+        Assertions.assertTrue(expected.bitLength() <= 128);
+        Assertions.assertEquals(expected.shiftRight(64).longValue(), hi,
+            () -> String.format("%s * %s", bi1, bi2));
+    }
+
+    /**
+     * Create a big integer treating the value as unsigned.
+     *
+     * @param v Value
+     * @return the big integer
+     */
+    private static BigInteger toUnsignedBigInteger(long v) {
+        return v < 0 ?
+            TWO_POW_63.add(BigInteger.valueOf(v & Long.MAX_VALUE)) :
+            BigInteger.valueOf(v);
+    }
+
+    /**
+     * Create a 128-bit big integer treating the value as unsigned.
+     *
+     * @param hi High part of value
+     * @param lo High part of value
+     * @return the big integer
+     */
+    private static BigInteger toUnsignedBigInteger(long hi, long lo) {
+        return toUnsignedBigInteger(hi).shiftLeft(64).add(toUnsignedBigInteger(lo));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "6364136223846793005, 1442695040888963407, 2738942865345",
+        // LXM 64-bit multiplier:
+        // -3372029247567499371 == 0xd1342543de82ef95L
+        "-3372029247567499371, 9832718632891239, 236823998",
+        "-3372029247567499371, -6152834681292394, -6378917984523",
+        "-3372029247567499371, 12638123, 21313",
+        "-3372029247567499371, -67123, 42",
+    })
+    void testLcgAdvancePow2(long m, long c, long state) {
+        // Bootstrap the first powers
+        long s = state;
+        for (int i = 0; i < 1; i++) {
+            s = m * s + c;
+        }
+        Assertions.assertEquals(s, lcgAdvancePow2(state, m, c, 0), "2^0 cycles");
+        for (int i = 0; i < 1; i++) {
+            s = m * s + c;
+        }
+        Assertions.assertEquals(s, lcgAdvancePow2(state, m, c, 1), "2^1 cycles");
+        for (int i = 0; i < 2; i++) {
+            s = m * s + c;
+        }
+        Assertions.assertEquals(s, lcgAdvancePow2(state, m, c, 2), "2^2 cycles");
+        for (int i = 0; i < 4; i++) {
+            s = m * s + c;
+        }
+        Assertions.assertEquals(s, lcgAdvancePow2(state, m, c, 3), "2^3 cycles");
+
+        // Larger powers should align
+        for (int n = 3; n < 63; n++) {
+            final int n1 = n + 1;
+            Assertions.assertEquals(
+                lcgAdvancePow2(lcgAdvancePow2(state, m, c, n), m, c, n),
+                lcgAdvancePow2(state, m, c, n1), () -> "2^" + n1 + " cycles");
+        }
+
+        // Larger/negative powers are ignored
+        for (final int i : new int[] {64, 67868, Integer.MAX_VALUE, Integer.MIN_VALUE, -26762, -2, -1}) {
+            final int n = i;
+            Assertions.assertEquals(state, lcgAdvancePow2(state, m, c, n),
+                () -> "2^" + n + " cycles");
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "126868183112323, 6364136223846793005, 1442695040888963407, 2738942865345, 3467819237274724, 12367842684328",
+        // Force carry when computing (m + 1) with ml = -1
+        "-126836182831123, -1, 12678162381123, -12673162838122, 12313212312354235, 127384628323784",
+        "92349876232, -1, 92374923739482, 2394782347892, 1239748923479, 627348278239",
+        // LXM 128-bit multiplier:
+        // -3024805186288043011 == 0xd605bbb58c8abbfdL
+        "1, -3024805186288043011, 9832718632891239, 236823998, -23564628723714323, -12361783268182",
+        "1, -3024805186288043011, -6152834681292394, -6378917984523, 127317381313, -12637618368172",
+        "1, -3024805186288043011, 1, 2, 3, 4",
+        "1, -3024805186288043011, -1, -78, -56775, 121",
+    })
+    void testLcg128AdvancePow2(long mh, long ml, long ch, long cl, long stateh, long statel) {
+        // Bootstrap the first powers
+        BigInteger s = toUnsignedBigInteger(stateh, statel);
+        final BigInteger m = toUnsignedBigInteger(mh, ml);
+        final BigInteger c = toUnsignedBigInteger(ch, cl);
+        for (int i = 0; i < 1; i++) {
+            s = m.multiply(s).add(c).mod(MOD);
+        }
+        Assertions.assertEquals(s.shiftRight(64).longValue(),
+            lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, 0), "2^0 cycles");
+        for (int i = 0; i < 1; i++) {
+            s = m.multiply(s).add(c).mod(MOD);
+        }
+        Assertions.assertEquals(s.shiftRight(64).longValue(),
+            lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, 1), "2^1 cycles");
+        for (int i = 0; i < 2; i++) {
+            s = m.multiply(s).add(c).mod(MOD);
+        }
+        Assertions.assertEquals(s.shiftRight(64).longValue(),
+            lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, 2), "2^2 cycles");
+        for (int i = 0; i < 4; i++) {
+            s = m.multiply(s).add(c).mod(MOD);
+        }
+        Assertions.assertEquals(s.shiftRight(64).longValue(),
+            lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, 3), "2^3 cycles");
+
+        // Larger powers should align
+        for (int n = 3; n < 127; n++) {
+            final int n1 = n + 1;
+            // The method under test does not return the lower half (by design) so
+            // we compute it using the same algorithm
+            final long lo = lcgAdvancePow2(statel, ml, cl, n);
+            final long hi = lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, n);
+            Assertions.assertEquals(
+                lcgAdvancePow2High(hi, lo, mh, ml, ch, cl, n),
+                lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, n1), () -> "2^" + n1 + " cycles");
+        }
+
+        // Larger/negative powers are ignored
+        for (final int i : new int[] {128, 67868, Integer.MAX_VALUE, Integer.MIN_VALUE, -26762, -2, -1}) {
+            final int n = i;
+            Assertions.assertEquals(stateh, lcgAdvancePow2High(stateh, statel, mh, ml, ch, cl, n),
+                () -> "2^" + n + " cycles");
+        }
+    }
+
+    @Test
+    void testLcg64Advance2Pow32Constants() {
+        // Computing with a addition of 1 will compute:
+        // m^(2^32)
+        // product { m^(2^i) + 1}  for i in [0, 31]
+        final long[] out = new long[2];
+        lcgAdvancePow2(LXMSupport.M64, 1, 32, out);
+        Assertions.assertEquals(LXMSupport.M64P, out[0], "m'");
+        Assertions.assertEquals(LXMSupport.C64P, out[1], "c'");
+        // Check the special values of the low half
+        Assertions.assertEquals(1, (int) out[0], "low m'");
+        Assertions.assertEquals(0, (int) out[1], "low c'");
+    }
+
+    @Test
+    void testLcg128Advance2Pow64Constants() {
+        // Computing with an addition of 1 will compute:
+        // m^(2^64)
+        // product { m^(2^i) + 1}  for i in [0, 63]
+        final long[] out = new long[4];
+        lcgAdvancePow2(1, LXMSupport.M128L, 0, 1, 64, out);
+        Assertions.assertEquals(LXMSupport.M128PH, out[0], "high m'");
+        Assertions.assertEquals(LXMSupport.C128PH, out[2], "high c'");
+        // These values are not stored.
+        // Their special values simplify the 128-bit multiplication.
+        Assertions.assertEquals(1, out[1], "low m'");
+        Assertions.assertEquals(0, out[3], "low c'");
+    }
+
+    /**
+     * Test the precomputed 64-bit LCG advance constant in {@link LXMSupport} matches the
+     * bootstrap tested generic version in this class.
+     */
+    @Test
+    void testLcgAdvance2Pow32() {
+        final SplittableRandom r = new SplittableRandom();
+        final long[] out = new long[2];
+
+        for (int i = 0; i < 2000; i++) {
+            // Must be odd
+            final long c = r.nextLong() | 1;
+            lcgAdvancePow2(LXMSupport.M64, c, 32, out);
+            final long a = out[1];
+            // Test assumptions
+            Assertions.assertEquals(1, (a >>> 32) & 0x1, "High half c' should be odd");
+            Assertions.assertEquals(0, (int) a, "Low half c' should be 0");
+            // This value can be computed from the constant
+            Assertions.assertEquals(a, LXMSupport.C64P * c);
+        }
+    }
+
+    /**
+     * Test the precomputed 128-bit LCG advance constant in {@link LXMSupport} matches the
+     * bootstrap tested generic version in this class.
+     */
+    @Test
+    void testLcgAdvance2Pow64() {
+        final SplittableRandom r = new SplittableRandom();
+        final long[] out = new long[4];
+
+        for (int i = 0; i < 2000; i++) {
+            // Must be odd for the assumptions
+            final long ch = r.nextLong();
+            final long cl = r.nextLong() | 1;
+            lcgAdvancePow2(1, LXMSupport.M128L, ch, cl, 64, out);
+            final long ah = out[2];
+            // Test assumptions
+            Assertions.assertEquals(1, ah & 0x1, "High half c' should be odd");
+            Assertions.assertEquals(0, out[3], "Low half c' should be 0");
+            // This value can be computed from the constant
+            Assertions.assertEquals(ah, LXMSupport.C128PH * cl);
+        }
+    }
+
+    /**
+     * Compute the multiplier {@code m'} and addition {@code c'} to advance the state of a
+     * 64-bit Linear Congruential Generator (LCG) a number of consecutive steps:
+     *
+     * <pre>
+     * s = m' * s + c'
+     * </pre>
+     *
+     * <p>A number of consecutive steps can be computed in a single multiply and add
+     * operation. This method computes the accumulated multiplier and addition for the
+     * given number of steps expressed as a power of 2. Provides support to advance for
+     * 2<sup>k</sup> for {@code k in [0, 63)}. Any power {@code >= 64} is ignored as this
+     * would wrap the generator to the same point. Negative powers are ignored but do not
+     * throw an exception.
+     *
+     * <p>Based on the algorithm from:
+     *
+     * <blockquote>Brown, F.B. (1994) Random number generation with arbitrary strides,
+     * Transactions of the American Nuclear Society 71.</blockquote>
+     *
+     * @param m Multiplier
+     * @param c Constant
+     * @param k Number of advance steps as a power of 2 (range [0, 63])
+     * @param out Output result [m', c']
+     * @see <A
+     * href="https://www.osti.gov/biblio/89100-random-number-generation-arbitrary-strides">
+     * Brown, F.B. (1994) Random number generation with arbitrary strides, Transactions of
+     * the American Nuclear Society 71</a>
+     */
+    private static void lcgAdvancePow2(long m, long c, int k, long[] out) {
+        // If any bits above the first 6 are set then this would wrap the generator to
+        // the same point as multiples of period (2^64).
+        // It also identifies negative powers to ignore.
+        if ((k & CLEAR_LOWER_6) != 0) {
+            // m'=1, c'=0
+            out[0] = 1;
+            out[1] = 0;
+            return;
+        }
+
+        long mp = m;
+        long a = c;
+
+        for (int i = k; i != 0; i--) {
+            // Update the multiplier and constant for the next power of 2
+            a = (mp + 1) * a;
+            mp *= mp;
+        }
+        out[0] = mp;
+        out[1] = a;
+    }
+
+    /**
+     * Compute the advanced state of a 64-bit Linear Congruential Generator (LCG). The
+     * base generator advance step is:
+     *
+     * <pre>
+     * s = m * s + c
+     * </pre>
+     *
+     * <p>A number of consecutive steps can be computed in a single multiply and add
+     * operation. This method computes the update coefficients and applies them to the
+     * given state.
+     *
+     * <p>This method is used for testing only. For arbitrary jumps an efficient implementation
+     * would inline the computation of the update coefficients; or for repeat jumps of the same
+     * size pre-compute the coefficients once.
+     *
+     * <p>This is package-private for use in {@link AbstractLXMTest} to provide jump functionality
+     * to a composite LXM generator.
+     *
+     * @param s State
+     * @param m Multiplier
+     * @param c Constant
+     * @param k Number of advance steps as a power of 2 (range [0, 63])
+     * @return the new state
+     * @see <A
+     * href="https://www.osti.gov/biblio/89100-random-number-generation-arbitrary-strides">
+     * Brown, F.B. (1994) Random number generation with arbitrary strides, Transactions of
+     * the American Nuclear Society 71</a>
+     */
+    static long lcgAdvancePow2(long s, long m, long c, int k) {
+        final long[] out = new long[2];
+        lcgAdvancePow2(m, c, k, out);
+        final long mp = out[0];
+        final long ap = out[1];
+        return mp * s + ap;
+    }
+
+    /**
+     * Compute the multiplier {@code m'} and addition {@code c'} to advance the state of a
+     * 128-bit Linear Congruential Generator (LCG) a number of consecutive steps:
+     *
+     * <pre>
+     * s = m' * s + c'
+     * </pre>
+     *
+     * <p>A number of consecutive steps can be computed in a single multiply and add
+     * operation. This method computes the accumulated multiplier and addition for the
+     * given number of steps expressed as a power of 2. Provides support to advance for
+     * 2<sup>k</sup> for {@code k in [0, 127)}. Any power {@code >= 128} is ignored as
+     * this would wrap the generator to the same point. Negative powers are ignored but do
+     * not throw an exception.
+     *
+     * <p>Note: The 128-bit state update can be computed using:
+     *
+     * <pre>
+     * // h=high part, l=low part
+     * // m * s + c
+     * sh = unsignedMultiplyHigh(ml, sl) + ml * sh + mh * sl + ch;
+     * // Carry propagation of
+     * // sl = ml * sl + cl
+     * final long u = ml * sl;
+     * sl = u + cl;
+     * if (Long.compareUnsigned(sl, u) < 0)
+     *     ++sh;
+     * </pre>
+     *
+     * <p>Based on the algorithm from:
+     *
+     * <blockquote>Brown, F.B. (1994) Random number generation with arbitrary strides,
+     * Transactions of the American Nuclear Society 71.</blockquote>
+     *
+     * <p>Note: If this is used for repeat jumps of a 128-bit LCG the multiplier and
+     * constant for the multiply-add operation are recomputed on each call. The
+     * alternative is to provide separate methods to: (a) compute the 256-bit [mh, ml, ch,
+     * cl] value; and (b) perform the state update from the [mh, ml, ch, cl] value. The
+     * precomputed value can be used to do repeat jumps for the computed power {@code k}
+     * and requires the LCG cache the jump computation.
+     *
+     * @param mh High half of multiplier
+     * @param ml Low half of multiplier
+     * @param ch High half of constant
+     * @param cl Low half of constant
+     * @param k Number of advance steps as a power of 2 (range [0, 127])
+     * @param out Output result [m', c'] packed as high-half, low-half of each constant
+     * @see <A
+     * href="https://www.osti.gov/biblio/89100-random-number-generation-arbitrary-strides">
+     * Brown, F.B. (1994) Random number generation with arbitrary strides, Transactions of
+     * the American Nuclear Society 71</a>
+     */
+    private static void lcgAdvancePow2(final long mh, final long ml,
+                                       final long ch, final long cl,
+                                       int k, long[] out) {
+        // If any bits above the first 7 are set then this would wrap the generator to
+        // the same point as multiples of period (2^128).
+        // It also identifies negative powers to ignore.
+        if ((k & CLEAR_LOWER_7) != 0) {
+            // m'=1, c'=0
+            out[0] = out[2] = out[3] = 0;
+            out[1] = 1;
+            return;
+        }
+
+        long mph = mh;
+        long mpl = ml;
+        long ah = ch;
+        long al = cl;
+
+        for (int i = k; i != 0; i--) {
+            // Update the multiplier and constant for the next power of 2
+            // c = (m + 1) * c
+            // Create (m + 1), carrying any overflow
+            final long mp1l = mpl + 1;
+            final long mp1h = mp1l == 0 ? mph + 1 : mph;
+            ah = LXMSupport.unsignedMultiplyHigh(mp1l, al) + mp1h * al + mp1l * ah;
+            al = mp1l * al;
+
+            // m = m * m
+            // Note: A dedicated unsignedSquareHigh in benchmarked in the JMH module
+            mph = LXMSupport.unsignedMultiplyHigh(mpl, mpl) + 2 * mph * mpl;
+            mpl = mpl * mpl;
+        }
+
+        out[0] = mph;
+        out[1] = mpl;
+        out[2] = ah;
+        out[3] = al;
+    }
+
+    /**
+     * Compute the advanced state of a 128-bit Linear Congruential Generator (LCG). The
+     * base generator advance step is:
+     *
+     * <pre>
+     * s = m * s + c
+     * </pre>
+     *
+     * <p>A number of consecutive steps can be computed in a single multiply and add
+     * operation. This method computes the update coefficients and applies them to the
+     * given state.
+     *
+     * <p>This method is used for testing only. For arbitrary jumps an efficient implementation
+     * would inline the computation of the update coefficients; or for repeat jumps of the same
+     * size pre-compute the coefficients once.
+     *
+     * <p>Note: Returns only the high-half of the state. For powers of 2 less than 64 the low
+     * half can be computed using {@link #lcgAdvancePow2(long, long, long, int)}.
+     *
+     * <p>This is package-private for use in {@link AbstractLXMTest} to provide jump functionality
+     * to a composite LXM generator.
+     *
+     * @param sh High half of state
+     * @param sl Low half of state
+     * @param mh High half of multiplier
+     * @param ml Low half of multiplier
+     * @param ch High half of constant
+     * @param cl Low half of constant
+     * @param k Number of advance steps as a power of 2 (range [0, 127])
+     * @return high half of the new state
+     * @see <A
+     * href="https://www.osti.gov/biblio/89100-random-number-generation-arbitrary-strides">
+     * Brown, F.B. (1994) Random number generation with arbitrary strides, Transactions of
+     * the American Nuclear Society 71</a>
+     */
+    static long lcgAdvancePow2High(long sh, long sl,
+                                   long mh, long ml,
+                                   long ch, long cl,
+                                   int k) {
+        final long[] out = new long[4];
+        lcgAdvancePow2(mh, ml, ch, cl, k, out);
+        final long mph = out[0];
+        final long mpl = out[1];
+        final long ah = out[2];
+        final long al = out[3];
+
+        // Perform the single update to the state
+        // m * s + c
+        long hi = LXMSupport.unsignedMultiplyHigh(mpl, sl) + mpl * sh + mph * sl + ah;
+        // Carry propagation of
+        // lo = sl * mpl + al
+        final long lo = sl * mpl;
+        if (Long.compareUnsigned(lo + al, lo) < 0) {
+            ++hi;
+        }
+        return hi;
+    }
+}

--- a/commons-rng-examples/examples-jmh/pom.xml
+++ b/commons-rng-examples/examples-jmh/pom.xml
@@ -81,6 +81,17 @@
        mvn test -DskipTests=false
     -->
     <skipTests>true</skipTests>
+
+    <!-- Java language level.
+        Increase to allow benchmarking with new JDK methods
+        for example Math.multiplyHigh (JDK 9) or Math.unsignedMultiplyHigh (JDK 18)
+        in LXMBenchmark. -->
+    <!--
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <animal.sniffer.skip>true</animal.sniffer.skip>
+    -->
+
   </properties>
 
   <profiles>

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/RandomSourceValues.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/RandomSourceValues.java
@@ -84,7 +84,14 @@ public class RandomSourceValues {
             "XO_RO_SHI_RO_1024_SS",
             "PCG_XSH_RR_32_OS",
             "PCG_XSH_RS_32_OS",
-            "PCG_RXS_M_XS_64_OS"})
+            "PCG_RXS_M_XS_64_OS",
+            "L64_X128_SS",
+            "L64_X128_MIX",
+            "L64_X256_MIX",
+            "L64_X1024_MIX",
+            "L128_X128_MIX",
+            "L128_X256_MIX",
+            "L128_X1024_MIX"})
     private String randomSourceName;
 
     /** The RandomSource. */

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/BaselineSources.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/BaselineSources.java
@@ -106,7 +106,14 @@ public abstract class BaselineSources {
             "XO_RO_SHI_RO_1024_SS",
             "PCG_XSH_RR_32_OS",
             "PCG_XSH_RS_32_OS",
-            "PCG_RXS_M_XS_64_OS"})
+            "PCG_RXS_M_XS_64_OS",
+            "L64_X128_SS",
+            "L64_X128_MIX",
+            "L64_X256_MIX",
+            "L64_X1024_MIX",
+            "L128_X128_MIX",
+            "L128_X256_MIX",
+            "L128_X1024_MIX"})
     private String randomSourceName;
 
     /** RNG. */

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/JumpBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/JumpBenchmark.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.examples.jmh.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.LongJumpableUniformRandomProvider;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Executes benchmark for jump operations of jumpable RNGs.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = { "-server", "-Xms128M", "-Xmx128M" })
+public class JumpBenchmark {
+    /**
+     * Encapsulates a method to jump an RNG.
+     */
+    @State(Scope.Benchmark)
+    public abstract static class BaseJumpableSource {
+        /** The generator of the next RNG copy from a jump. */
+        private Supplier<UniformRandomProvider> gen;
+
+        /**
+         * Perform a jump.
+         *
+         * @return the value
+         */
+        UniformRandomProvider jump() {
+            return gen.get();
+        }
+
+        /**
+         * Create the jump function.
+         */
+        @Setup
+        public void setup() {
+            gen = createJumpFunction();
+        }
+
+        /**
+         * Creates the jump function.
+         * The jump will copy the RNG and then move forward the state of the source
+         * RNG by a large number of steps. The copy is returned.
+         *
+         * @return the copy RNG
+         */
+        protected abstract Supplier<UniformRandomProvider> createJumpFunction();
+    }
+
+    /**
+     * Exercise the {@link JumpableUniformRandomProvider#jump()} function.
+     */
+    public static class JumpableSource extends BaseJumpableSource {
+        /**
+         * RNG providers.
+         *
+         * <p>Note: Some providers have exactly the same jump method so are commented out.
+         */
+        @Param({"XOR_SHIFT_1024_S",
+                //"XOR_SHIFT_1024_S_PHI",
+                "XO_SHI_RO_128_PLUS",
+                //"XO_SHI_RO_128_SS",
+                "XO_RO_SHI_RO_128_PLUS",
+                //"XO_RO_SHI_RO_128_SS",
+                "XO_SHI_RO_256_PLUS",
+                //"XO_SHI_RO_256_SS",
+                "XO_SHI_RO_512_PLUS",
+                //"XO_SHI_RO_512_SS",
+                //"XO_SHI_RO_128_PP",
+                "XO_RO_SHI_RO_128_PP", // Different update from XO_SHI_RO_128_PLUS
+                //"XO_SHI_RO_256_PP",
+                //"XO_SHI_RO_512_PP",
+                "XO_RO_SHI_RO_1024_PP",
+                //"XO_RO_SHI_RO_1024_S",
+                //"XO_RO_SHI_RO_1024_SS",
+                //"L64_X128_SS",
+                "L64_X128_MIX",
+                "L64_X256_MIX",
+                "L64_X1024_MIX",
+                "L128_X128_MIX",
+                "L128_X256_MIX",
+                "L128_X1024_MIX"})
+        private String randomSourceName;
+
+        /** {@inheritDoc} */
+        @Override
+        protected Supplier<UniformRandomProvider> createJumpFunction() {
+            final UniformRandomProvider rng = RandomSource.valueOf(randomSourceName).create();
+            if (rng instanceof JumpableUniformRandomProvider) {
+                return ((JumpableUniformRandomProvider) rng)::jump;
+            }
+            throw new IllegalStateException("Invalid jump source: " + randomSourceName);
+        }
+    }
+
+    /**
+     * Exercise the {@link LongJumpableUniformRandomProvider#longJump()} function.
+     *
+     * <p>Note: Any RNG with a long jump function also has a jump function.
+     * This list should be a subset of {@link JumpableSource}. Testing both methods
+     * is redundant unless the long jump function requires a more expensive routine.
+     * Providers listed here are expected to have a slower long jump.
+     *
+     * <p>Note: To test other providers the benchmark may be invoked using the
+     * JMH command line:
+     * <pre>
+     * java -jar target/examples-jmh.jar JumpBenchmark.longJump -p randomSourceName=L64_X128_MIX,L128_X128_MIX
+     * </pre>
+     */
+    public static class LongJumpableSource extends BaseJumpableSource {
+        /**
+         * Select RNG providers.
+         */
+        @Param({
+            // Requires the LCG to be advanced 2^32 rather than 1 cycle which
+            // can use precomputed coefficients.
+            "L64_X128_MIX",
+            "L64_X256_MIX",
+            "L64_X1024_MIX",
+            // Requires the LCG to be advanced 2^64 rather than 1 cycle which
+            // leaves the entire lower state unchanged and is computationally simpler
+            // using precomputed coefficients.
+            "L128_X128_MIX",
+            "L128_X256_MIX",
+            "L128_X1024_MIX",
+            })
+        private String randomSourceName;
+
+
+        /** {@inheritDoc} */
+        @Override
+        protected Supplier<UniformRandomProvider> createJumpFunction() {
+            final UniformRandomProvider rng = RandomSource.valueOf(randomSourceName).create();
+            if (rng instanceof LongJumpableUniformRandomProvider) {
+                return ((LongJumpableUniformRandomProvider) rng)::longJump;
+            }
+            throw new IllegalStateException("Invalid long jump source: " + randomSourceName);
+        }
+    }
+
+    /**
+     * Jump benchmark.
+     *
+     * @param data Source of the jump
+     * @return the copy
+     */
+    @Benchmark
+    public UniformRandomProvider jump(JumpableSource data) {
+        return data.jump();
+    }
+
+    /**
+     * Long jump benchmark.
+     *
+     * @param data Source of the long jump
+     * @return the copy
+     */
+    @Benchmark
+    public UniformRandomProvider longJump(LongJumpableSource data) {
+        return data.jump();
+    }
+}

--- a/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/LXMBenchmark.java
+++ b/commons-rng-examples/examples-jmh/src/main/java/org/apache/commons/rng/examples/jmh/core/LXMBenchmark.java
@@ -1,0 +1,975 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.rng.examples.jmh.core;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.stream.LongStream;
+import org.apache.commons.rng.JumpableUniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Executes a benchmark for operations used in the LXM family of RNGs.
+ *
+ * <h2>Note</h2>
+ *
+ * <p>Some code in this benchmark is commented out. It requires a higher
+ * version of Java than the current target. Bumping the JMH module to a higher
+ * minimum java version prevents running benchmarks on the target JVM for
+ * the Commons RNG artifacts. Thus these benchmarks must be manually reinstated by
+ * uncommenting the code and updating the Java version in the module pom.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = { "-server", "-Xms128M", "-Xmx128M" })
+public class LXMBenchmark {
+    /** Baseline for generation of 1 long value. */
+    private static final String BASELINE1 = "baseline1";
+    /** Baseline for generation of 2 long values. */
+    private static final String BASELINE2 = "baseline2";
+    /** Baseline for generation of 4 long values. */
+    private static final String BASELINE4 = "baseline4";
+
+    /**
+     * Encapsulates a method to compute an unsigned multiply of 64-bit values to create
+     * the upper and optionally low 64-bits of the 128-bit result.
+     *
+     * <p>This tests method used to compute an update of a 128-bit linear congruential
+     * generator (LCG).
+     */
+    @State(Scope.Benchmark)
+    public static class UnsignedMultiplyHighSource {
+        /** Low half of 128-bit LCG multiplier. The upper half is {@code 1L}. */
+        static final long M128L = 0xd605bbb58c8abbfdL;
+        /** A mask to convert an {@code int} to an unsigned integer stored as a {@code long}. */
+        private static final long INT_TO_UNSIGNED_BYTE_MASK = 0xffffffffL;
+        /** Precomputed upper split (32-bits) of the low half of the 128-bit multiplier constant. */
+        private static final long X = M128L >>> 32;
+        /** Precomputed lower split (32-bits) of the low half of the 128-bit multiplier constant. */
+        private static final long Y = M128L & INT_TO_UNSIGNED_BYTE_MASK;
+
+        /**
+         * The method to compute the value.
+         */
+        @Param({BASELINE1,
+            // Require JDK 9+
+            //"mathMultiplyHigh", "mathMultiplyHighWithML",
+            // Require JDK 18+
+            //"mathUnsignedMultiplyHigh", "mathUnsignedMultiplyHighWithML",
+            "unsignedMultiplyHigh", "unsignedMultiplyHighWithML",
+            "unsignedMultiplyHighML",
+            "unsignedMultiplyHighPlusMultiplyLow", "unsignedMultiplyHighAndLow",
+            })
+        private String method;
+
+        /** Flag to indicate numbers should be precomputed.
+         * Note: The multiply method is extremely fast and number generation can take
+         * significant part of the overall generation time. */
+        @Param({"true", "false"})
+        private boolean precompute;
+
+        /** The generator of the next value. */
+        private LongSupplier gen;
+
+        /**
+         * Compute the next value.
+         *
+         * @return the value
+         */
+        long next() {
+            return gen.getAsLong();
+        }
+
+        /**
+         * Create the generator of output values.
+         */
+        @Setup
+        public void setup() {
+            final JumpableUniformRandomProvider rng =
+                (JumpableUniformRandomProvider) RandomSource.XO_RO_SHI_RO_128_PP.create();
+
+            LongSupplier ga;
+            LongSupplier gb;
+
+            // Optionally precompute numbers.
+            if (precompute) {
+                final long[] values = LongStream.generate(rng::nextLong).limit(1024).toArray();
+                class A implements LongSupplier {
+                    private int i;
+                    @Override
+                    public long getAsLong() {
+                        return values[i++ & 1023];
+                    }
+                }
+                ga = new A();
+                class B implements LongSupplier {
+                    private int i;
+                    @Override
+                    public long getAsLong() {
+                        // Using any odd increment will sample all values (after wrapping)
+                        return values[(i += 3) & 1023];
+                    }
+                }
+                gb = new B();
+            } else {
+                ga = rng::nextLong;
+                gb = rng.jump()::nextLong;
+            }
+
+            if (BASELINE1.equals(method)) {
+                gen = () -> ga.getAsLong();
+            } else if (BASELINE2.equals(method)) {
+                gen = () -> ga.getAsLong() ^ gb.getAsLong();
+            } else if ("mathMultiplyHigh".equals(method)) {
+                gen = () -> mathMultiplyHigh(ga.getAsLong(), gb.getAsLong());
+            } else if ("mathMultiplyHighWithML".equals(method)) {
+                gen = () -> mathMultiplyHigh(ga.getAsLong(), M128L);
+            } else if ("mathUnsignedMultiplyHigh".equals(method)) {
+                gen = () -> mathUnsignedMultiplyHigh(ga.getAsLong(), gb.getAsLong());
+            } else if ("mathUnsignedMultiplyHighWithML".equals(method)) {
+                gen = () -> mathUnsignedMultiplyHigh(ga.getAsLong(), M128L);
+            } else if ("unsignedMultiplyHigh".equals(method)) {
+                gen = () -> unsignedMultiplyHigh(ga.getAsLong(), gb.getAsLong());
+            } else if ("unsignedMultiplyHighWithML".equals(method)) {
+                gen = () -> unsignedMultiplyHigh(ga.getAsLong(), M128L);
+            } else if ("unsignedMultiplyHighML".equals(method)) {
+                // Note:
+                // Running this benchmark should show the explicit precomputation
+                // of the ML parts does not increase performance. The JVM can
+                // optimise the call to unsignedMultiplyHigh(a, b) when b is constant.
+                gen = () -> unsignedMultiplyHighML(ga.getAsLong());
+            } else if ("unsignedMultiplyHighPlusMultiplyLow".equals(method)) {
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    return unsignedMultiplyHigh(a, b) ^ (a * b);
+                };
+            } else if ("unsignedMultiplyHighAndLow".equals(method)) {
+                // Note:
+                // Running this benchmark should show this method is slower.
+                // A CPU supporting parallel instructions can multiply (a*b)
+                // in parallel to calling unsignedMultiplyHigh.
+                final long[] lo = {0};
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long hi = unsignedMultiplyHigh(a, b, lo);
+                    return hi ^ lo[0];
+                };
+            } else {
+                throw new IllegalStateException("Unknown method: " + method);
+            }
+        }
+
+        /**
+         * Compute the unsigned multiply of two values using Math.multiplyHigh.
+         * <p>Requires JDK 9.
+         * From JDK 10 onwards this method is an intrinsic candidate.
+         *
+         * @param a First value
+         * @param b Second value
+         * @return the upper 64-bits of the 128-bit result
+         */
+        static long mathMultiplyHigh(long a, long b) {
+            // Requires JDK 9
+            // Note: Using runtime reflection to create a method handle
+            // has not been done to avoid any possible artifact during timing
+            // of this very fast method. To benchmark with this method
+            // requires uncommenting this code and compiling with an
+            // appropriate source level.
+            //return Math.multiplyHigh(a, b) + ((a >> 63) & b) + ((b >> 63) & a);
+            throw new NoSuchMethodError();
+        }
+
+        /**
+         * Compute the unsigned multiply of two values using Math.unsignedMultiplyHigh.
+         * <p>Requires JDK 18.
+         * This method is an intrinsic candidate.
+         *
+         * @param a First value
+         * @param b Second value
+         * @return the upper 64-bits of the 128-bit result
+         */
+        static long mathUnsignedMultiplyHigh(long a, long b) {
+            // Requires JDK 18
+            //return Math.unsignedMultiplyHigh(a, b);
+            throw new NoSuchMethodError();
+        }
+
+        /**
+         * Multiply the two values as if unsigned 64-bit longs to produce the high 64-bits
+         * of the 128-bit unsigned result.
+         *
+         * <p>This method computes the equivalent of:
+         * <pre>
+         * Math.multiplyHigh(a, b) + ((a >> 63) & b) + ((b >> 63) & a)
+         * </pre>
+         *
+         * <p>Note: The method {@code Math.multiplyHigh} was added in JDK 9
+         * and should be used as above when the source code targets Java 11
+         * to exploit the intrinsic method.
+         *
+         * <p>Note: The method {@code Math.unsignedMultiplyHigh} was added in JDK 18
+         * and should be used when the source code target allows.
+         *
+         * @param value1 the first value
+         * @param value2 the second value
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedMultiplyHigh(long value1, long value2) {
+            // Computation is based on the following observation about the upper (a and x)
+            // and lower (b and y) bits of unsigned big-endian integers:
+            //   ab * xy
+            // =  b *  y
+            // +  b * x0
+            // + a0 *  y
+            // + a0 * x0
+            // = b * y
+            // + b * x * 2^32
+            // + a * y * 2^32
+            // + a * x * 2^64
+            //
+            // Summation using a character for each byte:
+            //
+            //             byby byby
+            // +      bxbx bxbx 0000
+            // +      ayay ayay 0000
+            // + axax axax 0000 0000
+            //
+            // The summation can be rearranged to ensure no overflow given
+            // that the result of two unsigned 32-bit integers multiplied together
+            // plus two full 32-bit integers cannot overflow 64 bits:
+            // > long x = (1L << 32) - 1
+            // > x * x + x + x == -1 (all bits set, no overflow)
+            //
+            // The carry is a composed intermediate which will never overflow:
+            //
+            //             byby byby
+            // +           bxbx 0000
+            // +      ayay ayay 0000
+            //
+            // +      bxbx 0000 0000
+            // + axax axax 0000 0000
+
+            final long a = value1 >>> 32;
+            final long b = value1 & INT_TO_UNSIGNED_BYTE_MASK;
+            final long x = value2 >>> 32;
+            final long y = value2 & INT_TO_UNSIGNED_BYTE_MASK;
+
+
+            final long by = b * y;
+            final long bx = b * x;
+            final long ay = a * y;
+            final long ax = a * x;
+
+            // Cannot overflow
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                ay;
+            // Note:
+            // low = (carry << 32) | (by & INT_TO_UNSIGNED_BYTE_MASK)
+
+            return (bx >>> 32) + (carry >>> 32) + ax;
+        }
+
+        /**
+         * Multiply the two values as if unsigned 64-bit longs to produce the high
+         * 64-bits of the 128-bit unsigned result.
+         *
+         * @param value1 the first value
+         * @param value2 the second value
+         * @param low low 64-bits of the 128-bit result
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedMultiplyHigh(long value1, long value2, long[] low) {
+            final long a = value1 >>> 32;
+            final long b = value1 & INT_TO_UNSIGNED_BYTE_MASK;
+            final long x = value2 >>> 32;
+            final long y = value2 & INT_TO_UNSIGNED_BYTE_MASK;
+
+
+            final long by = b * y;
+            final long bx = b * x;
+            final long ay = a * y;
+            final long ax = a * x;
+
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                ay;
+
+            low[0] = (carry << 32) | (by & INT_TO_UNSIGNED_BYTE_MASK);
+
+            return (bx >>> 32) + (carry >>> 32) + ax;
+        }
+
+        /**
+         * Multiply the value as an unsigned 64-bit long by the constant
+         * {@code ML = 0xd605bbb58c8abbfdL} to produce the high 64-bits
+         * of the 128-bit unsigned result.
+         *
+         * <p>This is a specialised version of {@link #unsignedMultiplyHigh(long, long)}
+         * for use in the 128-bit LCG sub-generator of the LXM family.
+         *
+         * @param value the value
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedMultiplyHighML(long value) {
+            final long a = value >>> 32;
+            final long b = value & INT_TO_UNSIGNED_BYTE_MASK;
+
+            final long by = b * Y;
+            final long bx = b * X;
+            final long ay = a * Y;
+            final long ax = a * X;
+
+            // Cannot overflow
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                ay;
+
+            return (bx >>> 32) + (carry >>> 32) + ax;
+        }
+    }
+
+    /**
+     * Encapsulates a method to compute an unsigned multiply of two 128-bit values to create
+     * a truncated 128-bit result. The upper 128-bits of the 256-bit result are discarded.
+     * The upper and optionally low 64-bits of the truncated 128-bit result are computed.
+     *
+     * <p>This tests methods used during computation of jumps of size {@code 2^k} for a
+     * 128-bit linear congruential generator (LCG).
+     */
+    @State(Scope.Benchmark)
+    public static class UnsignedMultiply128Source {
+        /** A mask to convert an {@code int} to an unsigned integer stored as a {@code long}. */
+        private static final long INT_TO_UNSIGNED_BYTE_MASK = 0xffffffffL;
+
+        /**
+         * The method to compute the value.
+         */
+        @Param({BASELINE1,
+            "unsignedMultiplyHighPlusProducts",
+            "unsignedMultiply128AndLow",
+            "unsignedMultiplyHighPlusProducts (square)",
+            "unsignedSquareHighPlusProducts",
+            "unsignedMultiply128AndLow (square)",
+            "unsignedSquare128AndLow",
+            })
+        private String method;
+
+        /** Flag to indicate numbers should be precomputed.
+         * Note: The multiply method is extremely fast and number generation can take
+         * significant part of the overall generation time. */
+        @Param({"true", "false"})
+        private boolean precompute;
+
+        /** The generator of the next value. */
+        private LongSupplier gen;
+
+        /**
+         * Compute the next value.
+         *
+         * @return the value
+         */
+        long next() {
+            return gen.getAsLong();
+        }
+
+        /**
+         * Create the generator of output values.
+         */
+        @Setup
+        public void setup() {
+            final JumpableUniformRandomProvider rng =
+                (JumpableUniformRandomProvider) RandomSource.XO_RO_SHI_RO_128_PP.create();
+
+            LongSupplier ga;
+            LongSupplier gb;
+            LongSupplier gc;
+            LongSupplier gd;
+
+            // Optionally precompute numbers.
+            if (precompute) {
+                final long[] values = LongStream.generate(rng::nextLong).limit(1024).toArray();
+                class Gen implements LongSupplier {
+                    private int i;
+                    private final int inc;
+                    Gen(int inc) {
+                        this.inc = inc;
+                    }
+                    @Override
+                    public long getAsLong() {
+                        return values[(i += inc) & 1023];
+                    }
+                }
+                // Using any odd increment will sample all values (after wrapping)
+                ga = new Gen(1);
+                gb = new Gen(3);
+                gc = new Gen(5);
+                gd = new Gen(7);
+            } else {
+                ga = rng::nextLong;
+                gb = rng.jump()::nextLong;
+                gc = rng.jump()::nextLong;
+                gd = rng.jump()::nextLong;
+            }
+
+            if (BASELINE2.equals(method)) {
+                gen = () -> ga.getAsLong() ^ gb.getAsLong();
+            } else if (BASELINE4.equals(method)) {
+                gen = () -> ga.getAsLong() ^ gb.getAsLong() ^ gc.getAsLong() ^ gd.getAsLong();
+            } else if ("unsignedMultiplyHighPlusProducts".equals(method)) {
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long c = gc.getAsLong();
+                    final long d = gd.getAsLong();
+                    final long hi = UnsignedMultiplyHighSource.unsignedMultiplyHigh(b, d) +
+                                    a * d + b * c;
+                    final long lo = b * d;
+                    return hi ^ lo;
+                };
+            } else if ("unsignedMultiply128AndLow".equals(method)) {
+                // Note:
+                // Running this benchmark should show this method has no
+                // benefit over the explicit computation using unsignedMultiplyHigh
+                // and may actually be slower.
+                final long[] lo = {0};
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long c = gc.getAsLong();
+                    final long d = gd.getAsLong();
+                    final long hi = unsignedMultiply128(a, b, c, d, lo);
+                    return hi ^ lo[0];
+                };
+            } else if ("unsignedMultiplyHighPlusProducts (square)".equals(method)) {
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long hi = UnsignedMultiplyHighSource.unsignedMultiplyHigh(b, b) +
+                                    2 * a * b;
+                    final long lo = b * b;
+                    return hi ^ lo;
+                };
+            } else if ("unsignedSquareHighPlusProducts".equals(method)) {
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long hi = unsignedSquareHigh(b) +
+                                    2 * a * b;
+                    final long lo = b * b;
+                    return hi ^ lo;
+                };
+            } else if ("unsignedMultiply128AndLow (square)".equals(method)) {
+                final long[] lo = {0};
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long hi = unsignedMultiply128(a, b, a, b, lo);
+                    return hi ^ lo[0];
+                };
+            } else if ("unsignedSquare128AndLow".equals(method)) {
+                // Note:
+                // Running this benchmark should show this method has no
+                // benefit over the computation using unsignedMultiply128.
+                // The dedicated square method saves only 1 shift, 1 mask
+                // and 1 multiply operation.
+                final long[] lo = {0};
+                gen = () -> {
+                    final long a = ga.getAsLong();
+                    final long b = gb.getAsLong();
+                    final long hi = unsignedSquare128(a, b, lo);
+                    return hi ^ lo[0];
+                };
+            } else {
+                throw new IllegalStateException("Unknown 128-bit method: " + method);
+            }
+        }
+
+        /**
+         * Multiply the two values as if unsigned 128-bit longs to produce the 128-bit unsigned result.
+         * Note the result is a truncation of the full 256-bit result.
+         *
+         * <p>This is a extended version of {@link UnsignedMultiplyHighSource#unsignedMultiplyHigh(long, long)}
+         * for use in the 128-bit LCG sub-generator of the LXM family. It computes the equivalent of:
+         * <pre>
+         * long hi = unsignedMultiplyHigh(value1l, value2l) +
+         *           value1h * value2l + value1l * value2h;
+         * long lo = value1l * value2l;
+         * </pre>
+         *
+         * @param value1h the high bits of the first value
+         * @param value1l the low bits of the first value
+         * @param value2h the high bits of the second value
+         * @param value2l the low bits of the second value
+         * @param low the low bits of the 128-bit result (output to array index [0])
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedMultiply128(long value1h, long value1l, long value2h, long value2l,
+            long[] low) {
+
+            // Multiply the two low halves to compute an initial 128-bit result
+            final long a = value1l >>> 32;
+            final long b = value1l & INT_TO_UNSIGNED_BYTE_MASK;
+            final long x = value2l >>> 32;
+            final long y = value2l & INT_TO_UNSIGNED_BYTE_MASK;
+
+            final long by = b * y;
+            final long bx = b * x;
+            final long ay = a * y;
+            final long ax = a * x;
+
+            // Cannot overflow
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                ay;
+            low[0] = (carry << 32) | (by & INT_TO_UNSIGNED_BYTE_MASK);
+            final long high = (bx >>> 32) + (carry >>> 32) + ax;
+
+            // Incorporate the remaining high bits that do not overflow 128-bits
+            return high + value1h * value2l + value1l * value2h;
+        }
+
+        /**
+         * Square the value as if an unsigned 128-bit long to produce the 128-bit unsigned result.
+         *
+         * <p>This is a specialisation of {@link UnsignedMultiplyHighSource#unsignedMultiplyHigh(long, long)}
+         * for use in the 128-bit LCG sub-generator of the LXM family. It computes the equivalent of:
+         * <pre>
+         * unsignedMultiplyHigh(value, value);
+         * </pre>
+         *
+         * @param value the high bits of the value
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedSquareHigh(long value) {
+            final long a = value >>> 32;
+            final long b = value & INT_TO_UNSIGNED_BYTE_MASK;
+
+            final long by = b * b;
+            final long bx = b * a;
+            final long ax = a * a;
+
+            // Cannot overflow
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                bx;
+
+            return (bx >>> 32) + (carry >>> 32) + ax;
+        }
+
+        /**
+         * Square the value as if an unsigned 128-bit long to produce the 128-bit unsigned result.
+         *
+         * <p>This is a specialisation of {@link #unsignedMultiply128(long, long, long, long, long[])}
+         * for use in the 128-bit LCG sub-generator of the LXM family. It computes the equivalent of:
+         * <pre>
+         * long hi = unsignedMultiplyHigh(valueh, valuel, valueh, valuel) +
+         *           2 * valueh * valuel;
+         * long lo = valuel * valuel;
+         * </pre>
+         *
+         * @param valueh the high bits of the value
+         * @param valuel the low bits of the value
+         * @param low the low bits of the 128-bit result (output to array index [0])
+         * @return the high 64-bits of the 128-bit result
+         */
+        static long unsignedSquare128(long valueh, long valuel, long[] low) {
+
+            // Multiply the two low halves to compute an initial 128-bit result
+            final long a = valuel >>> 32;
+            final long b = valuel & INT_TO_UNSIGNED_BYTE_MASK;
+            // x = a, y = b
+
+            final long by = b * b;
+            final long bx = b * a;
+            // ay = bx
+            final long ax = a * a;
+
+            // Cannot overflow
+            final long carry = (by >>> 32) +
+                               (bx & INT_TO_UNSIGNED_BYTE_MASK) +
+                                bx;
+            low[0] = (carry << 32) | (by & INT_TO_UNSIGNED_BYTE_MASK);
+            final long high = (bx >>> 32) + (carry >>> 32) + ax;
+
+            // Incorporate the remaining high bits that do not overflow 128-bits
+            return high + 2 * valueh * valuel;
+        }
+    }
+
+    /**
+     * Encapsulates a method to compute an update step on a 128-bit linear congruential
+     * generator (LCG). This benchmark source targets optimisation of the 128-bit LCG update
+     * step, in particular the branch to compute carry propagation from the low to high half.
+     */
+    @State(Scope.Benchmark)
+    public static class LCG128Source {
+        /** Low half of 128-bit LCG multiplier. The upper half is {@code 1L}. */
+        static final long ML = 0xd605bbb58c8abbfdL;
+
+        /**
+         * The method to compute the value.
+         *
+         * <p>Final LCG additive parameters make no significant difference.
+         */
+        @Param({
+            "reference",
+            //"referenceFinal",
+            "compareUnsigned",
+            "conditional",
+            //"conditionalFinal",
+            })
+        private String method;
+
+        /**
+         * The low half of the additive parameter.
+         * This parameter determines how frequent the carry propagation
+         * must occur. The value is unsigned. When close to 0 then carry propagation
+         * is less frequent; increasingly large additions will make carry more likely.
+         * A value of -1 will always trigger a carry.
+         */
+        @Param({
+            // Uniformly spread in [0, 2^64)
+            // 1, [1 .. 4] * 2^62 - 1
+            //"1", "4611686018427387903", "9223372036854775807", "-4611686018427387905", "-1",
+
+            // 1, [1 .. 8] * 2^61 - 1
+            "1", "2305843009213693951", "4611686018427387903", "6917529027641081855",
+            "9223372036854775807", "-6917529027641081857", "-4611686018427387905",
+            "-2305843009213693953", "-1",
+            })
+        private long add;
+
+        /**
+         * Range for a random addition to the additive parameter.
+         * <ul>
+         * <li>{@code range == 0}: no addition
+         * <li>{@code range == Long.MIN_VALUE}: random addition
+         * <li>{@code range > 0}: random in [0, range)
+         * <li>{@code range < 0}: random in [0, -range) + 2^63
+         * </ul>
+         * If positive then any value in [0, range) is created.
+         * If negative then any value in 2^63 + [0, range) is created.
+         */
+        @Param({"0",
+            // 2^61
+            "2305843009213693952",
+            // MIN_VALUE
+            //"-9223372036854775808",
+            })
+        private long range;
+
+        /** The generator of the next value. */
+        private LongSupplier gen;
+
+        /**
+         * Compute the next value.
+         *
+         * @return the value
+         */
+        long next() {
+            return gen.getAsLong();
+        }
+
+        /**
+         * Create the generator of output values.
+         */
+        @Setup(Level.Iteration)
+        public void setup() {
+            final long ah = ThreadLocalRandom.current().nextLong();
+            long al = add;
+            // Choose to randomise the add parameter
+            if (range == Long.MIN_VALUE) {
+                // random addition
+                al += ThreadLocalRandom.current().nextLong();
+            } else if (range > 0) {
+                // [0, range)
+                al += ThreadLocalRandom.current().nextLong(range);
+            } else if (range < 0) {
+                // [0, -range) + 2^63
+                al += ThreadLocalRandom.current().nextLong(-range) + Long.MIN_VALUE;
+            }
+            // else range == 0: no addition
+            if ("reference".equals(method)) {
+                gen = new ReferenceLcg128(ah, al)::getAsLong;
+            } else if ("referenceFinal".equals(method)) {
+                gen = new ReferenceLcg128Final(ah, al)::getAsLong;
+            } else if ("compareUnsigned".equals(method)) {
+                gen = new CompareUnsignedLcg128(ah, al)::getAsLong;
+            } else if ("conditional".equals(method)) {
+                gen = new ConditionalLcg128(ah, al)::getAsLong;
+            } else if ("conditionalFinal".equals(method)) {
+                gen = new ConditionalLcg128Final(ah, al)::getAsLong;
+            } else {
+                throw new IllegalStateException("Unknown LCG method: " + method);
+            }
+        }
+
+        /**
+         * Base class for the 128-bit LCG. This holds the LCG state. It is initialised
+         * to 1 on construction. The value does not matter. The LCG additive parameter
+         * is what determines how frequent the carry propagation branch will be executed.
+         */
+        abstract static class BaseLcg128 implements LongSupplier {
+            /** High half of the 128-bit state of the LCG generator. */
+            protected long lsh;
+            /** Low half of the 128-bit state of the LCG generator. */
+            protected long lsl = 1;
+        }
+
+        /**
+         * Implements the 128-bit LCG using the reference code in Steele & Vigna (2021).
+         *
+         * <p>Note: the additive parameter is not final. This is due to the requirement
+         * for the LXM generator to implement
+         * {@link org.apache.commons.rng.RestorableUniformRandomProvider}.
+         */
+        static class ReferenceLcg128 extends BaseLcg128 {
+            /** High half of the 128-bit per-instance LCG additive parameter. */
+            private long lah;
+            /** Low half of the 128-bit per-instance LCG additive parameter (must be odd). */
+            private long lal;
+
+            /**
+             * @param ah High-half of add
+             * @param al Low-half of add
+             */
+            ReferenceLcg128(long ah, long al) {
+                lah = ah;
+                lal = al | 1;
+            }
+
+            @Override
+            public long getAsLong() {
+                // LCG update
+                // The LCG is, in effect, "s = m * s + a" where m = ((1LL << 64) + ML)
+                final long sh = lsh;
+                final long sl = lsl;
+                final long u = ML * sl;
+                // High half
+                lsh = ML * sh + UnsignedMultiplyHighSource.unsignedMultiplyHigh(ML, sl) + sl + lah;
+                // Low half
+                lsl = u + lal;
+                // Carry propagation
+                if (Long.compareUnsigned(lsl, u) < 0) {
+                    ++lsh;
+                }
+                return sh;
+            }
+        }
+
+        /**
+         * Implements the 128-bit LCG using the reference code in Steele & Vigna (2021).
+         * This uses a final additive parameter allowing the JVM to optimise.
+         */
+        static class ReferenceLcg128Final extends BaseLcg128 {
+            /** High half of the 128-bit per-instance LCG additive parameter. */
+            private final long lah;
+            /** Low half of the 128-bit per-instance LCG additive parameter (must be odd). */
+            private final long lal;
+
+            /**
+             * @param ah High-half of add
+             * @param al Low-half of add
+             */
+            ReferenceLcg128Final(long ah, long al) {
+                lah = ah;
+                lal = al | 1;
+            }
+
+            @Override
+            public long getAsLong() {
+                final long sh = lsh;
+                final long sl = lsl;
+                final long u = ML * sl;
+                // High half
+                lsh = ML * sh + UnsignedMultiplyHighSource.unsignedMultiplyHigh(ML, sl) + sl + lah;
+                // Low half
+                lsl = u + lal;
+                // Carry propagation
+                if (Long.compareUnsigned(lsl, u) < 0) {
+                    ++lsh;
+                }
+                return sh;
+            }
+        }
+
+        /**
+         * Implements the 128-bit LCG using the reference code in Steele & Vigna (2021)
+         * but directly implements the {@link Long#compareUnsigned(long, long)}.
+         *
+         * <p>Note: the additive parameter is not final. This is due to the requirement
+         * for the LXM generator to implement
+         * {@link org.apache.commons.rng.RestorableUniformRandomProvider}.
+         */
+        static class CompareUnsignedLcg128 extends BaseLcg128 {
+            /** High half of the 128-bit per-instance LCG additive parameter. */
+            private long lah;
+            /** Low half of the 128-bit per-instance LCG additive parameter (must be odd). */
+            private long lal;
+
+            /**
+             * @param ah High-half of add
+             * @param al Low-half of add
+             */
+            CompareUnsignedLcg128(long ah, long al) {
+                lah = ah;
+                lal = al | 1;
+            }
+
+            @Override
+            public long getAsLong() {
+                final long sh = lsh;
+                final long sl = lsl;
+                final long u = ML * sl;
+                // High half
+                lsh = ML * sh + UnsignedMultiplyHighSource.unsignedMultiplyHigh(ML, sl) + sl + lah;
+                // Low half
+                lsl = u + lal;
+                // Carry propagation using an unsigned compare
+                if (lsl + Long.MIN_VALUE < u + Long.MIN_VALUE) {
+                    ++lsh;
+                }
+                return sh;
+            }
+        }
+
+        /**
+         * Implements the 128-bit LCG using a conditional load in place of a branch
+         * statement for the carry. Uses a non-final additive parameter.
+         */
+        static class ConditionalLcg128 extends BaseLcg128 {
+            /** High half of the 128-bit per-instance LCG additive parameter. */
+            private long lah;
+            /** Low half of the 128-bit per-instance LCG additive parameter (must be odd). */
+            private long lal;
+
+            /**
+             * @param ah High-half of add
+             * @param al Low-half of add
+             */
+            ConditionalLcg128(long ah, long al) {
+                lah = ah;
+                lal = al | 1;
+            }
+
+            @Override
+            public long getAsLong() {
+                long sh = lsh;
+                long sl = lsl;
+                final long z = sh;
+                final long u = ML * sl;
+                // High half
+                sh = ML * sh + UnsignedMultiplyHighSource.unsignedMultiplyHigh(ML, sl) + sl + lah;
+                // Low half
+                sl = u + lal;
+                // Carry propagation using a conditional add of 1 or 0
+                lsh = (sl + Long.MIN_VALUE < u + Long.MIN_VALUE ? 1 : 0) + sh;
+                lsl = sl;
+                return z;
+            }
+        }
+
+        /**
+         * Implements the 128-bit LCG using a conditional load in place of a branch
+         * statement for the carry. Uses a final additive parameter.
+         */
+        static class ConditionalLcg128Final extends BaseLcg128 {
+            /** High half of the 128-bit per-instance LCG additive parameter. */
+            private final long lah;
+            /** Low half of the 128-bit per-instance LCG additive parameter (must be odd). */
+            private final long lal;
+
+            /**
+             * @param ah High-half of add
+             * @param al Low-half of add
+             */
+            ConditionalLcg128Final(long ah, long al) {
+                lah = ah;
+                lal = al | 1;
+            }
+
+            @Override
+            public long getAsLong() {
+                long sh = lsh;
+                long sl = lsl;
+                final long z = sh;
+                final long u = ML * sl;
+                // High half
+                sh = ML * sh + UnsignedMultiplyHighSource.unsignedMultiplyHigh(ML, sl) + sl + lah;
+                // Low half
+                sl = u + lal;
+                // Carry propagation using a conditional add of 1 or 0
+                lsh = (sl + Long.MIN_VALUE < u + Long.MIN_VALUE ? 1 : 0) + sh;
+                lsl = sl;
+                return z;
+            }
+        }
+    }
+
+    /**
+     * Unsigned multiply benchmark.
+     *
+     * @param data the data
+     * @return the value
+     */
+    @Benchmark
+    public long unsignedMultiply(UnsignedMultiplyHighSource data) {
+        return data.next();
+    }
+
+    /**
+     * 128-bit unsigned multiply benchmark.
+     *
+     * @param data the data
+     * @return the value
+     */
+    @Benchmark
+    public long unsignedMultiply128(UnsignedMultiply128Source data) {
+        return data.next();
+    }
+
+    /**
+     * 128-bit linear congruential generator benchmark.
+     *
+     * @param data the data
+     * @return the value
+     */
+    @Benchmark
+    public long lcg128(LCG128Source data) {
+        return data.next();
+    }
+}

--- a/commons-rng-examples/examples-jmh/src/test/java/org/apache/commons/rng/examples/jmh/core/LXMBenchmarkTest.java
+++ b/commons-rng-examples/examples-jmh/src/test/java/org/apache/commons/rng/examples/jmh/core/LXMBenchmarkTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rng.examples.jmh.core;
+
+import java.math.BigInteger;
+import java.util.function.LongSupplier;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.examples.jmh.core.LXMBenchmark.LCG128Source;
+import org.apache.commons.rng.examples.jmh.core.LXMBenchmark.UnsignedMultiply128Source;
+import org.apache.commons.rng.examples.jmh.core.LXMBenchmark.UnsignedMultiplyHighSource;
+import org.apache.commons.rng.simple.RandomSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * Test for methods used in {@link LXMBenchmark}. This checks the different versions of
+ * 128-bit multiplication compute the correct result (verified using BigInteger).
+ */
+class LXMBenchmarkTest {
+    /** 2^63. */
+    private static final BigInteger TWO_POW_63 = BigInteger.ONE.shiftLeft(63);
+
+    /**
+     * A function operating on 2 long values.
+     */
+    interface LongLongFunction {
+        /**
+         * Apply the function.
+         *
+         * @param a Argument a
+         * @param b Argument b
+         * @return the result
+         */
+        long apply(long a, long b);
+    }
+
+    /**
+     * A function operating on 4 long values.
+     */
+    interface LongLongLongLongFunction {
+        /**
+         * Apply the function.
+         *
+         * @param a Argument a
+         * @param b Argument b
+         * @param c Argument c
+         * @param d Argument d
+         * @return the result
+         */
+        long apply(long a, long b, long c, long d);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_9)
+    void testMathMultiplyHigh() {
+        try {
+            assertUnsignedMultiply(UnsignedMultiplyHighSource::mathMultiplyHigh, null);
+        } catch (NoSuchMethodError e) {
+            throw new TestAbortedException("Update mathMultiplyHigh to call Math.multiplyHigh");
+        }
+    }
+
+    @Test
+    // Note: JAVA_18 is not in the enum
+    @EnabledForJreRange(min = JRE.OTHER)
+    void testMathUnsignedMultiplyHigh() {
+        try {
+            assertUnsignedMultiply(UnsignedMultiplyHighSource::mathUnsignedMultiplyHigh, null);
+        } catch (NoSuchMethodError e) {
+            throw new TestAbortedException("Update mathUnsignedMultiplyHigh to call Math.unsignedMultiplyHigh");
+        }
+    }
+
+    @Test
+    void testUnsignedMultiplyHigh() {
+        assertUnsignedMultiply(UnsignedMultiplyHighSource::unsignedMultiplyHigh, null);
+    }
+
+    @Test
+    void testUnsignedMultiplyHighWithLow() {
+        final long[] lo = {0};
+        assertUnsignedMultiply((a, b) -> UnsignedMultiplyHighSource.unsignedMultiplyHigh(a, b, lo), lo);
+    }
+
+    private static void assertUnsignedMultiply(LongLongFunction fun, long[] lo) {
+        final UniformRandomProvider rng = RandomSource.JSF_64.create();
+        for (int i = 0; i < 100; i++) {
+            final long a = rng.nextLong();
+            final long b = rng.nextLong();
+            Assertions.assertEquals(unsignedMultiplyHigh(a, b),
+                                    fun.apply(a, b));
+            if (lo != null) {
+                Assertions.assertEquals(a * b, lo[0]);
+            }
+        }
+    }
+
+    @Test
+    void testUnsignedMultiplyHighML() {
+        final UniformRandomProvider rng = RandomSource.JSF_64.create();
+        final long b = UnsignedMultiplyHighSource.M128L;
+        for (int i = 0; i < 100; i++) {
+            final long a = rng.nextLong();
+            Assertions.assertEquals(unsignedMultiplyHigh(a, b),
+                UnsignedMultiplyHighSource.unsignedMultiplyHighML(a));
+        }
+    }
+
+    @Test
+    void testUnsignedMultiplyHighWithProducts() {
+        assertUnsignedMultiply128((a, b, c, d) ->
+            UnsignedMultiplyHighSource.unsignedMultiplyHigh(b, d) +
+            a * d + b * c, null);
+    }
+
+    @Test
+    void testUnsignedMultiply128() {
+        final long[] lo = {0};
+        assertUnsignedMultiply128((a, b, c, d) -> UnsignedMultiply128Source.unsignedMultiply128(a, b, c, d, lo), lo);
+    }
+
+    private static void assertUnsignedMultiply128(LongLongLongLongFunction fun, long[] lo) {
+        final UniformRandomProvider rng = RandomSource.JSF_64.create();
+        for (int i = 0; i < 100; i++) {
+            final long a = rng.nextLong();
+            final long b = rng.nextLong();
+            final long c = rng.nextLong();
+            final long d = rng.nextLong();
+            Assertions.assertEquals(unsignedMultiplyHigh(a, b, c, d),
+                                    fun.apply(a, b, c, d));
+            if (lo != null) {
+                Assertions.assertEquals(b * d, lo[0]);
+            }
+        }
+    }
+
+    @Test
+    void testUnsignedSquareHigh() {
+        final UniformRandomProvider rng = RandomSource.JSF_64.create();
+        for (int i = 0; i < 100; i++) {
+            final long a = rng.nextLong();
+            Assertions.assertEquals(unsignedMultiplyHigh(a, a),
+                                    UnsignedMultiply128Source.unsignedSquareHigh(a));
+        }
+    }
+
+    @Test
+    void testUnsignedSquare128() {
+        final long[] lo = {0};
+        final UniformRandomProvider rng = RandomSource.JSF_64.create();
+        for (int i = 0; i < 100; i++) {
+            final long a = rng.nextLong();
+            final long b = rng.nextLong();
+            Assertions.assertEquals(unsignedMultiplyHigh(a, b, a, b),
+                                    UnsignedMultiply128Source.unsignedSquare128(a, b, lo));
+            Assertions.assertEquals(b * b, lo[0]);
+        }
+    }
+
+    /**
+     * Compute the unsigned multiply of two values using BigInteger.
+     *
+     * @param a First value
+     * @param b Second value
+     * @return the upper 64-bits of the 128-bit result
+     */
+    private static long unsignedMultiplyHigh(long a, long b) {
+        final BigInteger ba = toUnsignedBigInteger(a);
+        final BigInteger bb = toUnsignedBigInteger(b);
+        return ba.multiply(bb).shiftRight(64).longValue();
+    }
+
+    /**
+     * Compute the unsigned multiply of two 128-bit values using BigInteger.
+     *
+     * <p>This computes the upper 64-bits of a 128-bit result that would
+     * be generated by multiplication to a native 128-bit integer type.
+     *
+     * @param a First value
+     * @param b Second value
+     * @return the upper 64-bits of the truncated 128-bit result
+     */
+    private static long unsignedMultiplyHigh(long ah, long al, long bh, long bl) {
+        final BigInteger a = toUnsignedBigInteger(ah, al);
+        final BigInteger b = toUnsignedBigInteger(bh, bl);
+        return a.multiply(b).shiftRight(64).longValue();
+    }
+
+    /**
+     * Create a big integer treating the value as unsigned.
+     *
+     * @param v Value
+     * @return the big integer
+     */
+    private static BigInteger toUnsignedBigInteger(long v) {
+        return v < 0 ?
+            TWO_POW_63.add(BigInteger.valueOf(v & Long.MAX_VALUE)) :
+            BigInteger.valueOf(v);
+    }
+
+    /**
+     * Create a 128-bit big integer treating the value as unsigned.
+     *
+     * @param hi High part of value
+     * @param lo High part of value
+     * @return the big integer
+     */
+    private static BigInteger toUnsignedBigInteger(long hi, long lo) {
+        return toUnsignedBigInteger(hi).shiftLeft(64).add(toUnsignedBigInteger(lo));
+    }
+
+    /**
+     * Test all 128-bit LCG implementations compute the same state update.
+     */
+    @RepeatedTest(value = 50)
+    void testLcg128() {
+        final long ah = RandomSource.createLong();
+        final long al = RandomSource.createLong();
+        final LongSupplier a = new LCG128Source.ReferenceLcg128(ah, al)::getAsLong;
+        final LongSupplier[] b = new LongSupplier[] {
+            new LCG128Source.ReferenceLcg128(ah, al)::getAsLong,
+            new LCG128Source.ReferenceLcg128Final(ah, al)::getAsLong,
+            new LCG128Source.CompareUnsignedLcg128(ah, al)::getAsLong,
+            new LCG128Source.ConditionalLcg128(ah, al)::getAsLong,
+            new LCG128Source.ConditionalLcg128Final(ah, al)::getAsLong,
+        };
+        for (int i = 0; i < 10; i++) {
+            final long expected = a.getAsLong();
+            for (int j = 0; j < b.length; j++) {
+                Assertions.assertEquals(expected, b[j].getAsLong());
+            }
+        }
+    }
+}

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/RandomSource.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/RandomSource.java
@@ -586,7 +586,70 @@ public enum RandomSource {
      * </ul>
      * @since 1.4
      */
-    PCG_RXS_M_XS_64_OS(ProviderBuilder.RandomSourceInternal.PCG_RXS_M_XS_64_OS);
+    PCG_RXS_M_XS_64_OS(ProviderBuilder.RandomSourceInternal.PCG_RXS_M_XS_64_OS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L64X128StarStar}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L64_X128_SS(ProviderBuilder.RandomSourceInternal.L64_X128_SS),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L64X128Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 4.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L64_X128_MIX(ProviderBuilder.RandomSourceInternal.L64_X128_MIX),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L64X256Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 6.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L64_X256_MIX(ProviderBuilder.RandomSourceInternal.L64_X256_MIX),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L64X1024Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 18.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L64_X1024_MIX(ProviderBuilder.RandomSourceInternal.L64_X1024_MIX),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L128X128Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 6.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L128_X128_MIX(ProviderBuilder.RandomSourceInternal.L128_X128_MIX),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L128X256Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 8.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L128_X256_MIX(ProviderBuilder.RandomSourceInternal.L128_X256_MIX),
+    /**
+     * Source of randomness is {@link org.apache.commons.rng.core.source64.L128X1024Mix}.
+     * <ul>
+     *  <li>Native seed type: {@code long[]}.</li>
+     *  <li>Native seed size: 20.</li>
+     * </ul>
+     * @since 1.5
+     */
+    L128_X1024_MIX(ProviderBuilder.RandomSourceInternal.L128_X1024_MIX);
 
     /** Internal identifier. */
     private final ProviderBuilder.RandomSourceInternal internalIdentifier;

--- a/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
+++ b/commons-rng-simple/src/main/java/org/apache/commons/rng/simple/internal/ProviderBuilder.java
@@ -65,6 +65,13 @@ import org.apache.commons.rng.core.source64.XoShiRo512StarStar;
 import org.apache.commons.rng.core.source64.PcgRxsMXs64;
 import org.apache.commons.rng.core.source64.DotyHumphreySmallFastCounting64;
 import org.apache.commons.rng.core.source64.JenkinsSmallFast64;
+import org.apache.commons.rng.core.source64.L64X1024Mix;
+import org.apache.commons.rng.core.source64.L64X128Mix;
+import org.apache.commons.rng.core.source64.L64X128StarStar;
+import org.apache.commons.rng.core.source64.L64X256Mix;
+import org.apache.commons.rng.core.source64.L128X1024Mix;
+import org.apache.commons.rng.core.source64.L128X128Mix;
+import org.apache.commons.rng.core.source64.L128X256Mix;
 
 /**
  * RNG builder.
@@ -366,7 +373,35 @@ public final class ProviderBuilder {
         /** Source of randomness is {@link PcgRxsMXs64}. */
         PCG_RXS_M_XS_64_OS(PcgRxsMXs64.class,
                 1,
-                NativeSeedType.LONG);
+                NativeSeedType.LONG),
+        /** Source of randomness is {@link L64X128StarStar}. */
+        L64_X128_SS(L64X128StarStar.class,
+                4,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L64X128Mix}. */
+        L64_X128_MIX(L64X128Mix.class,
+                4,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L64X256Mix}. */
+        L64_X256_MIX(L64X256Mix.class,
+                6,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L64X1024Mix}. */
+        L64_X1024_MIX(L64X1024Mix.class,
+                18,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L128X128Mix}. */
+        L128_X128_MIX(L128X128Mix.class,
+                6,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L128X256Mix}. */
+        L128_X256_MIX(L128X256Mix.class,
+                8,
+                NativeSeedType.LONG_ARRAY),
+        /** Source of randomness is {@link L128X1024Mix}. */
+        L128_X1024_MIX(L128X1024Mix.class,
+                20,
+                NativeSeedType.LONG_ARRAY);
 
         /** Source type. */
         private final Class<? extends UniformRandomProvider> rng;

--- a/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ProvidersList.java
+++ b/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/ProvidersList.java
@@ -91,6 +91,13 @@ public final class ProvidersList {
             add(LIST64, RandomSource.XO_RO_SHI_RO_1024_S, new long[] {-1574314L, 7879874453221215L, -7894343883216L});
             add(LIST64, RandomSource.XO_RO_SHI_RO_1024_SS, new long[] {-41514541234654321L, -12146412316546L, 7984134134L});
             add(LIST64, RandomSource.PCG_RXS_M_XS_64_OS, -34657834534L);
+            add(LIST64, RandomSource.L64_X128_SS, new long[] {-2379479823783L, -235642384324L, 123678172804389L});
+            add(LIST64, RandomSource.L64_X128_MIX, new long[] {-9723846672394L, 623748567398002L, -23678792345897934L});
+            add(LIST64, RandomSource.L64_X256_MIX, new long[] {236784568279L, 237894579279L, -2378945793L});
+            add(LIST64, RandomSource.L64_X1024_MIX, new long[] {279834579232345L, -2374689578237L, -2347895789327L});
+            add(LIST64, RandomSource.L128_X128_MIX, new long[] {236748567823789L, 237485792375L, 2374895789324L});
+            add(LIST64, RandomSource.L128_X256_MIX, new long[] {-829345782324L, -92304897238673245L, 28974785792345L});
+            add(LIST64, RandomSource.L128_X1024_MIX, new long[] {-6563745678920234L, 7348578274523L, 234523455234L});
             // ... add more here.
 
             // Do not modify the remaining statements.

--- a/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/internal/RandomSourceInternalParametricTest.java
+++ b/commons-rng-simple/src/test/java/org/apache/commons/rng/simple/internal/RandomSourceInternalParametricTest.java
@@ -98,6 +98,13 @@ class RandomSourceInternalParametricTest {
         EXPECTED_SEED_BYTES.put(RandomSourceInternal.PCG_XSH_RR_32_OS, longBytes);
         EXPECTED_SEED_BYTES.put(RandomSourceInternal.PCG_XSH_RS_32_OS, longBytes);
         EXPECTED_SEED_BYTES.put(RandomSourceInternal.PCG_RXS_M_XS_64_OS, longBytes);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L64_X128_SS, longBytes * 4);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L64_X128_MIX, longBytes * 4);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L64_X256_MIX, longBytes * 6);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L64_X1024_MIX, longBytes * 18);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L128_X128_MIX, longBytes * 6);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L128_X256_MIX, longBytes * 8);
+        EXPECTED_SEED_BYTES.put(RandomSourceInternal.L128_X1024_MIX, longBytes * 20);
         // ... add more here.
         // Verify the seed byte size is reflected in the enum javadoc for RandomSource.
     }

--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -22,6 +22,7 @@
   <!-- Special cases with many parameters for the constructor. -->
   <suppress checks="ParameterNumber" files="[\\/]LargeMeanPoissonSampler\.java$" />
   <suppress checks="ParameterNumber" files="source64[\\/].*XoShiRo512.*\.java$" />
+  <suppress checks="ParameterNumber" files="source64[\\/]L128X256Mix\.java$" />
   <suppress checks="UnnecessaryParentheses" files=".*stress[/\\]StressTestCommand\.java$" lines="672" />
   <!-- Special to allow withUniformRandomProvider to act as a constructor. -->
   <suppress checks="HiddenField" files=".*Sampler\.java$" message="'rng' hides a field." />

--- a/src/main/resources/pmd/pmd-ruleset.xml
+++ b/src/main/resources/pmd/pmd-ruleset.xml
@@ -101,6 +101,17 @@
       <property name="violationSuppressXPath" value="//ClassOrInterfaceDeclaration[@SimpleName='TSampler']"/>
     </properties>
   </rule>
+  <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters">
+    <properties>
+      <!-- Constructors can reassign their seed parameter after expanding it to the correct length -->
+      <!-- Mixers are optimised for code inlining -->
+      <property name="violationSuppressXPath"
+         value="./ancestor::ConstructorDeclaration[
+           (matches(@Image, 'L(64|128)X[0-9]+(StarStar|Mix)') and @Arity=1 and @Public=true())
+           or @Image='AbstractL64X128'] |
+           ./ancestor::MethodDeclaration[@Name='stafford13' or @Name='lea64']"/>
+    </properties>
+  </rule>
 
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
     <properties>
@@ -109,7 +120,7 @@
         value="//ClassOrInterfaceDeclaration[@SimpleName='ListSampler' or @SimpleName='ProviderBuilder'
           or @SimpleName='ThreadLocalRandomSource' or @SimpleName='SeedFactory'
           or @SimpleName='Coordinates' or @SimpleName='Hex' or @SimpleName='SpecialMath'
-          or @SimpleName='Conversions']"/>
+          or @SimpleName='Conversions' or @SimpleName='LXMSupport']"/>
       <!-- Allow samplers to have only factory constructors -->
       <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+(Utils?|Helper|Sampler)" />
     </properties>


### PR DESCRIPTION
Add support for generators included in JDK 17:

L64X128StarStar
L64X128Mix
L64X256Mix
L64X1024Mix
L128X128Mix
L128X256Mix
L128X1024Mix

Added benchmark for support routines for computing the unsigned long
multiplications in the 128-bit LCG (linear congruential generator).

Added a benchmark for the jump function to allow comparison with the
equivalent base XBG (xor-based generator).